### PR TITLE
Change the install/remove/refresh API to use single names.

### DIFF
--- a/example/info.dart
+++ b/example/info.dart
@@ -1,13 +1,14 @@
 import 'package:snapd/snapd.dart';
 
 void main(List<String> args) async {
-  if (args.isEmpty) {
+  if (args.length != 1) {
     print('Usage: info <snap>');
     return;
   }
+  var name = args[0];
 
   var client = SnapdClient();
-  var snaps = await client.find(name: args[0]);
+  var snaps = await client.find(name: name);
   var snap = snaps[0];
 
   var publisher = snap.publisher?.displayName;

--- a/example/install.dart
+++ b/example/install.dart
@@ -1,14 +1,15 @@
 import 'package:snapd/snapd.dart';
 
 void main(List<String> args) async {
-  if (args.isEmpty) {
+  if (args.length != 1) {
     print('Usage: install <snap>');
     return;
   }
+  var name = args[0];
 
   var client = SnapdClient();
   await client.loadAuthorization();
-  var id = await client.install(args);
+  var id = await client.install(name);
   while (true) {
     var change = await client.getChange(id);
     if (change.ready) {

--- a/example/refresh.dart
+++ b/example/refresh.dart
@@ -1,14 +1,15 @@
 import 'package:snapd/snapd.dart';
 
 void main(List<String> args) async {
+  if (args.length != 1) {
+    print('Usage: refresh <snap>');
+    return;
+  }
+  var name = args[0];
+
   var client = SnapdClient();
   await client.loadAuthorization();
-  String id;
-  if (args.isNotEmpty) {
-    id = await client.refresh(names: args);
-  } else {
-    id = await client.refresh();
-  }
+  var id = await client.refresh(name);
   while (true) {
     var change = await client.getChange(id);
     if (change.ready) {

--- a/example/remove.dart
+++ b/example/remove.dart
@@ -1,14 +1,15 @@
 import 'package:snapd/snapd.dart';
 
 void main(List<String> args) async {
-  if (args.isEmpty) {
+  if (args.length != 1) {
     print('Usage: remove <snap>');
     return;
   }
+  var name = args[0];
 
   var client = SnapdClient();
   await client.loadAuthorization();
-  var id = await client.remove(args);
+  var id = await client.remove(name);
   while (true) {
     var change = await client.getChange(id);
     if (change.ready) {

--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -943,16 +943,16 @@ class SnapdClient {
     await _postSync('/v2/logout', {'id': id});
   }
 
-  /// Installs the snaps with the given [names].
+  /// Installs the snap with the given [name].
   /// Returns the change ID for this operation, use [getChange] to get the status of this operation.
-  Future<String> install(List<String> names,
+  Future<String> install(String name,
       {String? channel,
       String? revision,
       bool classic = false,
       bool dangerous = false,
       bool devmode = false,
       bool jailmode = false}) async {
-    var request = {'action': 'install', 'snaps': names};
+    var request = <String, dynamic>{'action': 'install'};
     if (channel != null) {
       request['channel'] = channel;
     }
@@ -971,32 +971,31 @@ class SnapdClient {
     if (jailmode) {
       request['jailmode'] = true;
     }
-    return await _postAsync('/v2/snaps', request);
+    var path = '/v2/snaps/' + Uri.encodeComponent(name);
+    return await _postAsync(path, request);
   }
 
-  /// Refreshes the snaps with the given [names].
-  /// If no names provided refreshes all snaps.
+  /// Refreshes the snap with the given [name].
   /// Returns the change ID for this operation, use [getChange] to get the status of this operation.
-  Future<String> refresh({List<String>? names, String? channel}) async {
+  Future<String> refresh(String name, {String? channel}) async {
     var request = {};
     request['action'] = 'refresh';
-    if (names != null) {
-      request['snaps'] = names;
-    }
     if (channel != null) {
       request['channel'] = channel;
     }
-    return await _postAsync('/v2/snaps', request);
+    var path = '/v2/snaps/' + Uri.encodeComponent(name);
+    return await _postAsync(path, request);
   }
 
-  /// Removes the snaps with the given [names].
+  /// Removes the snap with the given [name].
   /// Returns the change ID for this operation, use [getChange] to get the status of this operation.
-  Future<String> remove(List<String> names, {bool purge = false}) async {
-    var request = {'action': 'remove', 'snaps': names};
+  Future<String> remove(String name, {bool purge = false}) async {
+    var request = <String, dynamic>{'action': 'remove'};
     if (purge) {
       request['purge'] = true;
     }
-    return await _postAsync('/v2/snaps', request);
+    var path = '/v2/snaps/' + Uri.encodeComponent(name);
+    return await _postAsync(path, request);
   }
 
   /// Gets the status the change with the given [id].


### PR DESCRIPTION
The multiple use API doesn't seem to work with the classic flag.
Switch to the single API, which matches what snapd-glib does and is probably more likely to be used.
If necessary, we can add back a multiple install API later.