### PR TITLE
[WIP] feat: data classes based on Dart 3 records

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          explicit_to_json: true
+          field_rename: kebab

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,1 +1,3 @@
 comment: false
+ignore:
+  - "**/*.g.dart"

--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -1,7 +1,11 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:collection/collection.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+
+part 'snapd_client.g.dart';
 
 /// The current state of a snap.
 enum SnapStatus { unknown, available, priced, installed, active }
@@ -21,27 +25,15 @@ enum SnapdConnectionFilter { all }
 /// Filter to select which apps to return from a collection search.
 enum SnapFindFilter { refresh, private }
 
-DateTime? _parseDateTime(String? value) {
-  return value != null ? DateTime.parse(value) : null;
-}
+class _SnapdDateTimeConverter implements JsonConverter<DateTime, String?> {
+  const _SnapdDateTimeConverter();
 
-SnapStatus _parseStatus(String? value) {
-  return {
-        'available': SnapStatus.available,
-        'priced': SnapStatus.priced,
-        'installed': SnapStatus.installed,
-        'active': SnapStatus.active
-      }[value] ??
-      SnapStatus.unknown;
-}
+  @override
+  DateTime fromJson(String? json) =>
+      json != null ? DateTime.parse(json) : DateTime.utc(1970);
 
-SnapConfinement _parseConfinement(String? value) {
-  return {
-        'strict': SnapConfinement.strict,
-        'classic': SnapConfinement.classic,
-        'devmode': SnapConfinement.devmode
-      }[value] ??
-      SnapConfinement.unknown;
+  @override
+  String? toJson(DateTime value) => value.toIso8601String();
 }
 
 /// An exception thrown by a request to snapd.
@@ -59,88 +51,95 @@ class SnapdException implements Exception {
 }
 
 /// Describes an app provided by a snap.
+@immutable
+@JsonSerializable()
 class SnapApp {
   /// The snap this app is part of
-  final String? snap;
+  String? get snap => _data.snap;
 
   /// Name of the app.
-  final String name;
+  String get name => _data.name;
 
   /// Desktop file the app uses.
-  final String? desktopFile;
+  String? get desktopFile => _data.desktopFile;
 
   /// Type of daemon this app is.
-  final String? daemon;
+  String? get daemon => _data.daemon;
 
   /// True if this service is enabled.
-  final bool enabled;
+  bool get enabled => _data.enabled;
 
   /// True if this service is active.
-  final bool active;
+  bool get active => _data.active;
 
   /// A unique ID for this app.
-  final String? commonId;
+  String? get commonId => _data.commonId;
 
   // FIXME(robert-ancell) Implement
-  //List<SnapActivator> activators.
+  //List<SnapActivator> get activators => _data.activators.asList();
 
   const SnapApp(
-      {required this.snap,
-      required this.name,
-      this.desktopFile,
-      this.daemon,
-      this.enabled = true,
-      this.active = true,
-      this.commonId});
+      {required String? snap,
+      required String name,
+      String? desktopFile,
+      String? daemon,
+      bool enabled = true,
+      bool active = true,
+      String? commonId})
+      : _data = (
+          snap: snap,
+          name: name,
+          desktopFile: desktopFile,
+          daemon: daemon,
+          enabled: enabled,
+          active: active,
+          commonId: commonId,
+        );
 
-  factory SnapApp._fromJson(Map<String, dynamic> value) {
-    return SnapApp(
-        snap: value['snap'],
-        name: value['name'],
-        desktopFile: value['desktop-file'],
-        daemon: value['daemon'],
-        enabled: value['enabled'] ?? true,
-        active: value['active'] ?? true,
-        commonId: value['common-id']);
-  }
+  final ({
+    String? snap,
+    String name,
+    String? desktopFile,
+    String? daemon,
+    bool enabled,
+    bool active,
+    String? commonId,
+  }) _data;
 
-  @override
-  String toString() =>
-      '$runtimeType(snap: $snap, name: $name, desktopFile: $desktopFile, daemon: $daemon, enabled: $enabled, active: $active, commonId: $commonId)';
+  factory SnapApp.fromJson(Map<String, dynamic> json) =>
+      _$SnapAppFromJson(json);
 
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is SnapApp &&
-        other.snap == snap &&
-        other.name == name &&
-        other.desktopFile == desktopFile &&
-        other.daemon == daemon &&
-        other.enabled == enabled &&
-        other.active == active &&
-        other.commonId == commonId;
-  }
+  Map<String, dynamic> toJson() => _$SnapAppToJson(this);
 
   @override
-  int get hashCode =>
-      Object.hash(snap, name, desktopFile, daemon, enabled, active, commonId);
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) => other is SnapApp && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Describes an category this snap is part of.
+@immutable
+@JsonSerializable()
 class SnapCategory {
   /// Name of the category this snap is in.
-  final String name;
+  String get name => _data.name;
 
   /// True if this snap is featured in this category.
-  final bool featured;
+  bool get featured => _data.featured;
 
-  const SnapCategory({required this.name, this.featured = false});
+  const SnapCategory({required String name, bool featured = false})
+      : _data = (name: name, featured: featured);
 
-  factory SnapCategory._fromJson(value) {
-    return SnapCategory(
-        name: value['name'] ?? '', featured: value['featured'] ?? false);
-  }
+  final ({String name, bool featured}) _data;
+
+  factory SnapCategory.fromJson(Map<String, dynamic> json) =>
+      _$SnapCategoryFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapCategoryToJson(this);
 
   @override
   String toString() => '$runtimeType(name: $name, featured: $featured)';
@@ -159,1019 +158,1021 @@ class SnapCategory {
 }
 
 /// Describes a snap category.
+@immutable
+@JsonSerializable()
 class SnapdCategoryDetails {
   /// Name of the category.
-  final String name;
+  String get name => _data.name;
 
-  const SnapdCategoryDetails({required this.name});
+  const SnapdCategoryDetails({required String name}) : _data = (name: name);
 
-  factory SnapdCategoryDetails._fromJson(value) {
-    return SnapdCategoryDetails(name: value['name'] ?? '');
-  }
+  final ({String name}) _data;
 
-  @override
-  String toString() => '$runtimeType(name: $name)';
+  factory SnapdCategoryDetails.fromJson(Map<String, dynamic> json) =>
+      _$SnapdCategoryDetailsFromJson(json);
 
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is SnapdCategoryDetails && other.name == name;
-  }
+  Map<String, dynamic> toJson() => _$SnapdCategoryDetailsToJson(this);
 
   @override
-  int get hashCode => name.hashCode;
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapdCategoryDetails && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Describes a channel available for a snap.
+@immutable
+@JsonSerializable()
 class SnapChannel {
   /// Confinement of this snap in this channel.
-  final SnapConfinement confinement;
+  SnapConfinement get confinement => _data.confinement;
 
   /// The date this revision was released into the channel.
-  final DateTime releasedAt;
+  @_SnapdDateTimeConverter()
+  DateTime get releasedAt => _data.releasedAt;
 
   /// Revision of this snap in this channel.
-  final String revision;
+  String get revision => _data.revision;
 
   /// Size of the snap in this channel in bytes.
-  final int size;
+  int get size => _data.size;
 
   /// Version of this snap in this channel.
-  final String version;
+  String get version => _data.version;
 
   const SnapChannel(
-      {this.confinement = SnapConfinement.unknown,
-      required this.releasedAt,
-      this.revision = '',
-      this.size = 0,
-      this.version = ''});
+      {SnapConfinement confinement = SnapConfinement.unknown,
+      required DateTime releasedAt,
+      String revision = '',
+      int size = 0,
+      String version = ''})
+      : _data = (
+          confinement: confinement,
+          releasedAt: releasedAt,
+          revision: revision,
+          size: size,
+          version: version,
+        );
 
-  factory SnapChannel._fromJson(value) {
-    return SnapChannel(
-        confinement: _parseConfinement(value['confinement']),
-        releasedAt: _parseDateTime(value['released-at']) ?? DateTime.utc(1970),
-        revision: value['revision'] ?? '',
-        size: value['size'] ?? 0,
-        version: value['version'] ?? '');
-  }
+  final ({
+    SnapConfinement confinement,
+    DateTime releasedAt,
+    String revision,
+    int size,
+    String version,
+  }) _data;
 
-  @override
-  String toString() =>
-      '$runtimeType(confinement: $confinement, releasedAt: $releasedAt, revision: $revision, size: $size, version: $version)';
+  factory SnapChannel.fromJson(Map<String, dynamic> json) =>
+      _$SnapChannelFromJson(json);
 
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is SnapChannel &&
-        other.confinement == confinement &&
-        other.releasedAt == releasedAt &&
-        other.revision == revision &&
-        other.size == size &&
-        other.version == version;
-  }
+  Map<String, dynamic> toJson() => _$SnapChannelToJson(this);
 
   @override
-  int get hashCode =>
-      Object.hash(confinement, releasedAt, revision, size, version);
+  String toString() => '$runtimeType($_data)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapChannel && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Describes a snap publisher.
+@immutable
+@JsonSerializable()
 class SnapPublisher {
   /// Unique ID for this publisher.
-  final String id;
+  String get id => _data.id;
 
   /// Unique username for this publisher.
-  final String username;
+  String get username => _data.username;
 
   /// Name to use when displaying this publisher.
-  final String displayName;
+  String get displayName => _data.displayName;
 
   /// Validation level for this publisher.
-  final String? validation;
+  String? get validation => _data.validation;
 
   const SnapPublisher(
-      {this.id = '',
-      this.username = '',
-      this.displayName = '',
-      this.validation});
+      {String id = '',
+      String username = '',
+      String displayName = '',
+      String? validation})
+      : _data = (
+          id: id,
+          username: username,
+          displayName: displayName,
+          validation: validation,
+        );
 
-  factory SnapPublisher._fromJson(value) {
-    return SnapPublisher(
-        id: value['id'] ?? '',
-        username: value['username'] ?? '',
-        displayName: value['display-name'] ?? '',
-        validation: value['validation']);
-  }
+  final ({
+    String id,
+    String username,
+    String displayName,
+    String? validation,
+  }) _data;
 
-  @override
-  String toString() =>
-      '$runtimeType(id: $id, username: $username, displayName: $displayName, validation: $validation)';
+  factory SnapPublisher.fromJson(Map<String, dynamic> json) =>
+      _$SnapPublisherFromJson(json);
 
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is SnapPublisher &&
-        other.id == id &&
-        other.username == username &&
-        other.displayName == displayName &&
-        other.validation == validation;
-  }
+  Map<String, dynamic> toJson() => _$SnapPublisherToJson(this);
 
   @override
-  int get hashCode => Object.hash(id, username, displayName, validation);
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapPublisher && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Describes a piece of media associated with a snap.
+@immutable
+@JsonSerializable()
 class SnapMedia {
   /// Media type
-  final String type;
+  String get type => _data.type;
 
   /// URL of media.
-  final String url;
+  String get url => _data.url;
 
   /// Width of media in pixels.
-  final int? width;
+  int? get width => _data.width;
 
   /// Height of media in pixels.
-  final int? height;
+  int? get height => _data.height;
 
   const SnapMedia(
-      {required this.type, required this.url, this.width, this.height});
+      {required String type, required String url, int? width, int? height})
+      : _data = (type: type, url: url, width: width, height: height);
 
-  factory SnapMedia._fromJson(value) {
-    return SnapMedia(
-        type: value['type'] ?? '',
-        url: value['url'] ?? '',
-        width: value['width'],
-        height: value['height']);
-  }
+  final ({
+    String type,
+    String url,
+    int? width,
+    int? height,
+  }) _data;
 
-  @override
-  String toString() =>
-      '$runtimeType(type: $type, url: $url, width: $width, height: $height)';
+  factory SnapMedia.fromJson(Map<String, dynamic> json) =>
+      _$SnapMediaFromJson(json);
 
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is SnapMedia &&
-        other.type == type &&
-        other.url == url &&
-        other.width == width &&
-        other.height == height;
-  }
+  Map<String, dynamic> toJson() => _$SnapMediaToJson(this);
 
   @override
-  int get hashCode => Object.hash(type, url, width, height);
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) => other is SnapMedia && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Describes a snap package.
+@immutable
+@JsonSerializable()
 class Snap {
   /// Apps this snap provides.
-  final List<SnapApp> apps;
+  List<SnapApp> get apps => _data.apps.asList();
 
   /// The base snap this snap uses.
-  final String? base;
+  String? get base => _data.base;
 
   /// Categories this snap belongs to.
-  final List<SnapCategory> categories;
+  List<SnapCategory> get categories => _data.categories.asList();
 
   /// The channel this snap is from, e.g. "stable".
-  final String channel;
+  String get channel => _data.channel;
 
   /// Channels available for this snap.
-  final Map<String, SnapChannel> channels;
+  Map<String, SnapChannel> get channels => _data.channels.asMap();
 
   /// Common IDs this snap contains.
-  final List<String> commonIds;
+  List<String> get commonIds => _data.commonIds.asList();
 
   /// The confinement this snap is using.
-  final SnapConfinement confinement;
+  SnapConfinement get confinement => _data.confinement;
 
   /// Contact URL.
-  final String? contact;
+  String? get contact => _data.contact;
 
   /// Multi line description.
-  final String description;
+  String get description => _data.description;
 
   /// True if this snap is running in developer mode.
-  final bool devmode;
+  bool get devmode => _data.devmode;
 
   /// Download size in bytes.
-  final int? downloadSize;
+  int? get downloadSize => _data.downloadSize;
 
   /// The date this snap will re-enable autmatic refreshing or null if no hold is present.
-  final DateTime? hold;
+  DateTime? get hold => _data.hold;
 
   /// Unique ID for this snap.
-  final String id;
+  String get id => _data.id;
 
   /// The date this snap was installed.
-  final DateTime? installDate;
+  DateTime? get installDate => _data.installDate;
 
   /// Installed size in bytes.
-  final int? installedSize;
+  int? get installedSize => _data.installedSize;
 
   /// True if this snap is running in enforced confinement (jail) mode.
-  final bool jailmode;
+  bool get jailmode => _data.jailmode;
 
   /// Package license.
-  final String? license;
+  String? get license => _data.license;
 
   /// Media associated with this snap.
-  final List<SnapMedia> media;
+  List<SnapMedia> get media => _data.media.asList();
 
   /// The path this snap is mounted from, which is a .snap file for installed snaps and a directory for snaps in try mode.
-  final String? mountedFrom;
+  String? get mountedFrom => _data.mountedFrom;
 
   /// Unique name for this snap. Use [title] for displaying.
-  final String name;
+  String get name => _data.name;
 
   /// True if this snap is only available to the developer.
-  final bool private;
+  bool get private => _data.private;
 
   /// Publisher information.
-  final SnapPublisher? publisher;
+  SnapPublisher? get publisher => _data.publisher;
 
   /// Revision of this snap.
-  final String revision;
+  String get revision => _data.revision;
 
   /// The current status of this snap.
-  final SnapStatus status;
+  SnapStatus get status => _data.status;
 
   /// URL linking to the snap store page on this snap.
-  final String? storeUrl;
+  String? get storeUrl => _data.storeUrl;
 
   /// Single line summary.
-  final String summary;
+  String get summary => _data.summary;
 
   /// Title of this snap.
-  final String? title;
+  String? get title => _data.title;
 
   /// The channel that updates will be installed from, e.g. "stable".
-  final String? trackingChannel;
+  String? get trackingChannel => _data.trackingChannel;
 
   /// Tracks this snap uses.
-  final List<String> tracks;
+  List<String> get tracks => _data.tracks.asList();
 
   /// Type of snap.
-  final String type;
+  String get type => _data.type;
 
   /// Version of this snap.
-  final String version;
+  String get version => _data.version;
 
   /// Website URL.
-  final String? website;
+  String? get website => _data.website;
 
-  const Snap(
-      {this.apps = const [],
-      this.base,
-      this.categories = const [],
-      this.channel = '',
-      this.channels = const {},
-      this.commonIds = const [],
-      this.confinement = SnapConfinement.unknown,
-      this.contact = '',
-      this.description = '',
-      this.devmode = false,
-      this.downloadSize,
-      this.hold,
-      this.id = '',
-      this.installDate,
-      this.installedSize,
-      this.jailmode = false,
-      this.license,
-      this.media = const [],
-      this.mountedFrom,
-      required this.name,
-      this.private = false,
-      this.publisher,
-      this.revision = '',
-      this.status = SnapStatus.unknown,
-      this.storeUrl,
-      this.summary = '',
-      this.title = '',
-      this.trackingChannel,
-      this.tracks = const [],
-      this.type = '',
-      this.version = '',
-      this.website});
+  Snap(
+      {List<SnapApp> apps = const [],
+      String? base,
+      List<SnapCategory> categories = const [],
+      String channel = '',
+      Map<String, SnapChannel> channels = const {},
+      List<String> commonIds = const [],
+      SnapConfinement confinement = SnapConfinement.unknown,
+      String? contact = '',
+      String description = '',
+      bool devmode = false,
+      int? downloadSize,
+      DateTime? hold,
+      String id = '',
+      DateTime? installDate,
+      int? installedSize,
+      bool jailmode = false,
+      String? license,
+      List<SnapMedia> media = const [],
+      String? mountedFrom,
+      required String name,
+      bool private = false,
+      SnapPublisher? publisher,
+      String revision = '',
+      SnapStatus status = SnapStatus.unknown,
+      String? storeUrl,
+      String summary = '',
+      String? title,
+      String? trackingChannel,
+      List<String> tracks = const [],
+      String type = '',
+      String version = '',
+      String? website})
+      : _data = (
+          apps: BuiltList(apps),
+          base: base,
+          categories: BuiltList(categories),
+          channel: channel,
+          channels: BuiltMap(channels),
+          commonIds: BuiltList(commonIds),
+          confinement: confinement,
+          contact: contact,
+          description: description,
+          devmode: devmode,
+          downloadSize: downloadSize,
+          hold: hold,
+          id: id,
+          installDate: installDate,
+          installedSize: installedSize,
+          jailmode: jailmode,
+          license: license,
+          media: BuiltList(media),
+          mountedFrom: mountedFrom,
+          name: name,
+          private: private,
+          publisher: publisher,
+          revision: revision,
+          status: status,
+          storeUrl: storeUrl,
+          summary: summary,
+          title: title,
+          trackingChannel: trackingChannel,
+          tracks: BuiltList(tracks),
+          type: type,
+          version: version,
+          website: website,
+        );
 
-  factory Snap._fromJson(Map<String, dynamic> value) {
-    return Snap(
-        apps: value['apps'] != null
-            ? (value['apps'] as List).map((v) => SnapApp._fromJson(v)).toList()
-            : [],
-        base: value['base'],
-        categories: value['categories'] != null
-            ? (value['categories'] as List)
-                .map((v) => SnapCategory._fromJson(v))
-                .toList()
-            : [],
-        channel: value['channel'],
-        channels: value['channels'] != null
-            ? (value['channels'] as Map)
-                .map((k, v) => MapEntry(k, SnapChannel._fromJson(v)))
-            : {},
-        commonIds: value['common-ids']?.cast<String>() ?? [],
-        confinement: _parseConfinement(value['confinement']),
-        contact: value['contact'] ?? '',
-        description: value['description'] ?? '',
-        devmode: value['devmode'] ?? false,
-        downloadSize: value['download-size'],
-        hold: _parseDateTime(value['hold']),
-        id: value['id'],
-        installDate: _parseDateTime(value['install-date']),
-        installedSize: value['installed-size'],
-        jailmode: value['jailmode'] ?? false,
-        license: value['license'],
-        mountedFrom: value['mounted-from'],
-        media: value['media'] != null
-            ? (value['media'] as List)
-                .map((v) => SnapMedia._fromJson(v))
-                .toList()
-            : [],
-        name: value['name'],
-        private: value['private'] ?? false,
-        publisher: value['publisher'] != null
-            ? SnapPublisher._fromJson(value['publisher'])
-            : null,
-        revision: value['revision'] ?? '',
-        storeUrl: value['store-url'],
-        summary: value['summary'],
-        status: _parseStatus(value['status']),
-        title: value['title'],
-        trackingChannel: value['tracking-channel'],
-        tracks: value['tracks']?.cast<String>() ?? [],
-        type: value['type'] ?? '',
-        version: value['version'] ?? '',
-        website: value['website']);
-  }
+  final ({
+    BuiltList<SnapApp> apps,
+    String? base,
+    BuiltList<SnapCategory> categories,
+    String channel,
+    BuiltMap<String, SnapChannel> channels,
+    BuiltList<String> commonIds,
+    SnapConfinement confinement,
+    String? contact,
+    String description,
+    bool devmode,
+    int? downloadSize,
+    DateTime? hold,
+    String id,
+    DateTime? installDate,
+    int? installedSize,
+    bool jailmode,
+    String? license,
+    BuiltList<SnapMedia> media,
+    String? mountedFrom,
+    String name,
+    bool private,
+    SnapPublisher? publisher,
+    String revision,
+    SnapStatus status,
+    String? storeUrl,
+    String summary,
+    String? title,
+    String? trackingChannel,
+    BuiltList<String> tracks,
+    String type,
+    String version,
+    String? website,
+  }) _data;
 
-  @override
-  String toString() =>
-      "$runtimeType(apps: $apps, base: $base, categories: $categories, channel: $channel, channels: $channels, commonIds: $commonIds, confinement: $confinement, contact: $contact, description: '${description.replaceAll('\n', '\\n')}', devmode: $devmode, downloadSize: $downloadSize, hold: $hold, id: $id, installDate: $installDate, installedSize: $installedSize, jailmode: $jailmode, license: $license, media: $media, mountedFrom: $mountedFrom, name: $name, private: $private, publisher: $publisher, revision: $revision, status: $status, storeUrl: $storeUrl, summary: '$summary', title: '$title', trackingChannel: $trackingChannel, tracks: $tracks, type: $type, version: $version, website: $website)";
+  factory Snap.fromJson(Map<String, dynamic> json) => _$SnapFromJson(json);
 
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    final deepEquals = const DeepCollectionEquality().equals;
-
-    return other is Snap &&
-        deepEquals(other.apps, apps) &&
-        other.base == base &&
-        deepEquals(other.categories, categories) &&
-        other.channel == channel &&
-        deepEquals(other.channels, channels) &&
-        deepEquals(other.commonIds, commonIds) &&
-        other.confinement == confinement &&
-        other.contact == contact &&
-        other.description == description &&
-        other.devmode == devmode &&
-        other.downloadSize == downloadSize &&
-        other.hold == hold &&
-        other.id == id &&
-        other.installDate == installDate &&
-        other.installedSize == installedSize &&
-        other.jailmode == jailmode &&
-        other.license == license &&
-        deepEquals(other.media, media) &&
-        other.mountedFrom == mountedFrom &&
-        other.name == name &&
-        other.private == private &&
-        other.publisher == publisher &&
-        other.revision == revision &&
-        other.status == status &&
-        other.storeUrl == storeUrl &&
-        other.summary == summary &&
-        other.title == title &&
-        other.trackingChannel == trackingChannel &&
-        deepEquals(other.tracks, tracks) &&
-        other.type == type &&
-        other.version == version &&
-        other.website == website;
-  }
+  Map<String, dynamic> toJson() => _$SnapToJson(this);
 
   @override
-  int get hashCode {
-    final deepHash = const DeepCollectionEquality().hash;
-    return Object.hashAll([
-      deepHash(apps),
-      base,
-      deepHash(categories),
-      channel,
-      deepHash(channels),
-      deepHash(commonIds),
-      confinement,
-      contact,
-      description,
-      devmode,
-      downloadSize,
-      hold,
-      id,
-      installDate,
-      installedSize,
-      jailmode,
-      license,
-      deepHash(media),
-      mountedFrom,
-      name,
-      private,
-      publisher,
-      revision,
-      status,
-      storeUrl,
-      summary,
-      title,
-      trackingChannel,
-      deepHash(tracks),
-      type,
-      version,
-      website
-    ]);
-  }
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) => other is Snap && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Response received when getting system information.
+@immutable
+@JsonSerializable()
 class SnapdSystemInfoResponse {
   /// The architecture snapd is running on.
-  final String architecture;
+  String get architecture => _data.architecture;
 
   /// The build of snapd.
-  final String buildId;
+  String get buildId => _data.buildId;
 
   /// The confinement level that is supported.
-  final SnapConfinement confinement;
+  SnapConfinement get confinement => _data.confinement;
 
   /// The version of the Linux kernel this is running on.
-  final String kernelVersion;
+  String get kernelVersion => _data.kernelVersion;
 
   // FIXME(robert-ancell): locations
 
-  final bool managed;
+  bool get managed => _data.managed;
 
   /// True if running on a classic system.
-  final bool onClassic;
+  bool get onClassic => _data.onClassic;
 
   // FIXME(robert-ancell): os-release
 
-  /// The last time the system refreshed.
-  final DateTime? refreshLast;
-
-  /// The next time the system refreshed.
-  final DateTime refreshNext;
-
-  // FIXME(robert-ancell): Refresh timer.
-  //String refreshTimer;
+  /// Contains information about refreshes.
+  SnapdSystemRefreshInfo get refresh => _data.refresh;
 
   // FIXME(robert-ancell): sandbox-features
 
   /// The core series in use.
-  final String series;
+  String get series => _data.series;
 
-  final String systemMode;
+  String get systemMode => _data.systemMode;
 
   /// The version of snapd.
-  final String version;
+  String get version => _data.version;
 
   const SnapdSystemInfoResponse(
-      {this.architecture = '',
-      this.buildId = '',
-      this.confinement = SnapConfinement.unknown,
-      this.kernelVersion = '',
-      this.managed = false,
-      this.onClassic = false,
-      this.refreshLast,
-      required this.refreshNext,
-      this.series = '',
-      this.systemMode = '',
-      this.version = ''});
+      {String architecture = '',
+      String buildId = '',
+      SnapConfinement confinement = SnapConfinement.unknown,
+      String kernelVersion = '',
+      bool managed = false,
+      bool onClassic = false,
+      required SnapdSystemRefreshInfo refresh,
+      String series = '',
+      String systemMode = '',
+      String version = ''})
+      : _data = (
+          architecture: architecture,
+          buildId: buildId,
+          confinement: confinement,
+          kernelVersion: kernelVersion,
+          managed: managed,
+          onClassic: onClassic,
+          refresh: refresh,
+          series: series,
+          systemMode: systemMode,
+          version: version,
+        );
 
-  factory SnapdSystemInfoResponse._fromJson(value) {
-    var refresh = value['refresh'];
-    return SnapdSystemInfoResponse(
-        architecture: value['architecture'] ?? '',
-        buildId: value['build-id'] ?? '',
-        confinement: _parseConfinement(value['confinement']),
-        kernelVersion: value['kernel-version'] ?? '',
-        managed: value['managed'] ?? false,
-        onClassic: value['on-classic'] ?? false,
-        refreshLast: refresh != null ? _parseDateTime(refresh['last']) : null,
-        refreshNext:
-            (refresh != null ? _parseDateTime(refresh['next']) : null) ??
-                DateTime.utc(1970),
-        series: value['series'] ?? '',
-        systemMode: value['system-mode'] ?? '',
-        version: value['version'] ?? '');
-  }
+  final ({
+    String architecture,
+    String buildId,
+    SnapConfinement confinement,
+    String kernelVersion,
+    bool managed,
+    bool onClassic,
+    SnapdSystemRefreshInfo refresh,
+    String series,
+    String systemMode,
+    String version,
+  }) _data;
+
+  factory SnapdSystemInfoResponse.fromJson(Map<String, dynamic> json) =>
+      _$SnapdSystemInfoResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapdSystemInfoResponseToJson(this);
 
   @override
-  String toString() =>
-      '$runtimeType(architecture: $architecture, buildId: $buildId, confinement: $confinement, kernelVersion: $kernelVersion, managed: $managed, onClassic: $onClassic, refreshLast: $refreshLast, refreshNext: $refreshNext, series: $series, systemMode: $systemMode, version: $version)';
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapdSystemInfoResponse && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
+}
+
+/// Contains information about refreshes.
+@immutable
+@JsonSerializable()
+class SnapdSystemRefreshInfo {
+  /// The last time the system refreshed.
+  DateTime? get last => _data.last;
+
+  /// The next time the system refreshed.
+  @_SnapdDateTimeConverter()
+  DateTime get next => _data.next;
+
+  // FIXME(robert-ancell): Refresh timer.
+  //String get timer => _data.timer;
+
+  const SnapdSystemRefreshInfo({DateTime? last, required DateTime next})
+      : _data = (last: last, next: next);
+
+  final ({DateTime? last, DateTime next}) _data;
+
+  factory SnapdSystemRefreshInfo.fromJson(Map<String, dynamic> json) =>
+      _$SnapdSystemRefreshInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapdSystemRefreshInfoToJson(this);
+
+  @override
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapdSystemRefreshInfo && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Response received when logging in.
+@immutable
+@JsonSerializable()
 class SnapdLoginResponse {
   /// Id for this account, which can be used in [SnapdClient.logout].
-  final int id;
+  int get id => _data.id;
 
   /// Username logged in with.
-  final String? username;
+  String? get username => _data.username;
 
   /// Email address logged in with.
-  final String? email;
+  String? get email => _data.email;
 
   /// Macaroon provided by the server.
-  final String? macaroon;
+  String? get macaroon => _data.macaroon;
 
   /// Discharges provided bu the server.
-  final List<String> discharges;
+  List<String> get discharges => _data.discharges.asList();
 
   /// Secure Shell keys this user has.
-  final List<String> sshKeys;
+  List<String> get sshKeys => _data.sshKeys.asList();
 
-  const SnapdLoginResponse(
-      {required this.id,
-      this.username,
-      this.email,
-      this.macaroon,
-      this.discharges = const [],
-      this.sshKeys = const []});
+  SnapdLoginResponse(
+      {required int id,
+      String? username,
+      String? email,
+      String? macaroon,
+      List<String> discharges = const [],
+      List<String> sshKeys = const []})
+      : _data = (
+          id: id,
+          username: username,
+          email: email,
+          macaroon: macaroon,
+          discharges: BuiltList(discharges),
+          sshKeys: BuiltList(sshKeys),
+        );
 
-  factory SnapdLoginResponse._fromJson(value) {
-    return SnapdLoginResponse(
-        id: value['id'],
-        username: value['username'],
-        email: value['email'],
-        macaroon: value['macaroon'],
-        discharges: value['discharges'].cast<String>() ?? [],
-        sshKeys: value['ssh-keys'].cast<String>() ?? []);
-  }
+  final ({
+    int id,
+    String? username,
+    String? email,
+    String? macaroon,
+    BuiltList<String> discharges,
+    BuiltList<String> sshKeys,
+  }) _data;
+
+  factory SnapdLoginResponse.fromJson(Map<String, dynamic> json) =>
+      _$SnapdLoginResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapdLoginResponseToJson(this);
 
   @override
-  String toString() =>
-      '$runtimeType(id: $id, username: $username, email: $email, macaroon: $macaroon, discharges: $discharges)';
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapdLoginResponse && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Information on a snap plug.
+@immutable
+@JsonSerializable()
 class SnapPlug {
   /// The snap this plug is provided by.
-  final String snap;
+  String get snap => _data.snap;
 
   /// The plug name.
-  final String plug;
+  String get plug => _data.plug;
 
   // Attributes for the plug.
-  final Map<String, dynamic> attributes;
+  @JsonKey(name: 'attrs')
+  Map<String, dynamic> get attributes => _data.attributes.asMap();
 
   /// The interface this plug uses.
-  final String? interface;
+  String? get interface => _data.interface;
 
   // Slots connected to this plug.
-  final List<SnapSlot> connections;
+  List<SnapSlot> get connections => _data.connections.asList();
 
-  const SnapPlug(
-      {required this.snap,
-      required this.plug,
-      this.attributes = const {},
-      this.interface,
-      this.connections = const []});
+  SnapPlug(
+      {required String snap,
+      required String plug,
+      Map<String, dynamic> attributes = const {},
+      String? interface,
+      List<SnapSlot> connections = const []})
+      : _data = (
+          snap: snap,
+          plug: plug,
+          attributes: BuiltMap(attributes),
+          interface: interface,
+          connections: BuiltList(connections),
+        );
 
-  factory SnapPlug._fromJson(value) {
-    return SnapPlug(
-        snap: value['snap'] ?? '',
-        plug: value['plug'] ?? '',
-        attributes: value['attrs']?.cast<String, dynamic>() ?? {},
-        interface: value['interface'],
-        connections: value['connections']
-                ?.map<SnapSlot>((v) => SnapSlot._fromJson(v))
-                ?.toList() ??
-            []);
-  }
+  final ({
+    String snap,
+    String plug,
+    BuiltMap<String, dynamic> attributes,
+    String? interface,
+    BuiltList<SnapSlot> connections,
+  }) _data;
 
-  @override
-  String toString() {
-    var values = {'snap': snap, 'plug': plug};
-    if (attributes.isNotEmpty) {
-      values['attributes'] = '$attributes';
-    }
-    if (interface != null) {
-      values['interface'] = '$interface';
-    }
-    if (connections.isNotEmpty) {
-      values['connections'] = '$connections';
-    }
-    var args = values.entries.map((e) => '${e.key}: ${e.value}').join(', ');
-    return '$runtimeType($args)';
-  }
+  factory SnapPlug.fromJson(Map<String, dynamic> json) =>
+      _$SnapPlugFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapPlugToJson(this);
 
   @override
-  bool operator ==(other) {
-    if (identical(this, other)) return true;
-    final deepEquals = const DeepCollectionEquality().equals;
-
-    return other is SnapPlug &&
-        other.snap == snap &&
-        other.plug == plug &&
-        deepEquals(other.attributes, attributes) &&
-        other.interface == interface &&
-        deepEquals(other.connections, connections);
-  }
+  String toString() => '$runtimeType$_data';
 
   @override
-  int get hashCode => Object.hash(
-      snap,
-      plug,
-      Object.hashAllUnordered(
-          attributes.entries.map((e) => Object.hash(e.key, e.value))),
-      interface,
-      Object.hashAll(connections));
+  bool operator ==(Object other) => other is SnapPlug && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Information on a snap slot.
+@immutable
+@JsonSerializable()
 class SnapSlot {
   /// The snap this slot is provided by.
-  final String snap;
+  String get snap => _data.snap;
 
   /// The slot name.
-  final String slot;
+  String get slot => _data.slot;
 
   // Attributes for the slot.
-  final Map<String, dynamic> attributes;
+  @JsonKey(name: 'attrs')
+  Map<String, dynamic> get attributes => _data.attributes.asMap();
 
   /// The interface this slot uses.
-  final String? interface;
+  String? get interface => _data.interface;
 
   // Plugs connected to this slot.
-  final List<SnapPlug> connections;
+  List<SnapPlug> get connections => _data.connections.asList();
 
-  const SnapSlot(
-      {required this.snap,
-      required this.slot,
-      this.attributes = const {},
-      this.interface,
-      this.connections = const []});
+  SnapSlot(
+      {required String snap,
+      required String slot,
+      Map<String, dynamic> attributes = const {},
+      String? interface,
+      List<SnapPlug> connections = const []})
+      : _data = (
+          snap: snap,
+          slot: slot,
+          attributes: BuiltMap(attributes),
+          interface: interface,
+          connections: BuiltList(connections),
+        );
 
-  factory SnapSlot._fromJson(value) {
-    return SnapSlot(
-        snap: value['snap'] ?? '',
-        slot: value['slot'] ?? '',
-        attributes: value['attrs']?.cast<String, dynamic>() ?? {},
-        interface: value['interface'],
-        connections: value['connections']
-                ?.map<SnapPlug>((v) => SnapPlug._fromJson(v))
-                ?.toList() ??
-            []);
-  }
+  final ({
+    String snap,
+    String slot,
+    BuiltMap<String, dynamic> attributes,
+    String? interface,
+    BuiltList<SnapPlug> connections,
+  }) _data;
 
-  @override
-  String toString() {
-    var values = {'snap': snap, 'slot': slot};
-    if (attributes.isNotEmpty) {
-      values['attributes'] = '$attributes';
-    }
-    if (interface != null) {
-      values['interface'] = '$interface';
-    }
-    if (connections.isNotEmpty) {
-      values['connections'] = '$connections';
-    }
-    var args = values.entries.map((e) => '${e.key}: ${e.value}').join(', ');
-    return '$runtimeType($args)';
-  }
+  factory SnapSlot.fromJson(Map<String, dynamic> json) =>
+      _$SnapSlotFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapSlotToJson(this);
 
   @override
-  bool operator ==(other) {
-    if (identical(this, other)) return true;
-    final deepEquals = const DeepCollectionEquality().equals;
-
-    return other is SnapSlot &&
-        other.snap == snap &&
-        other.slot == slot &&
-        deepEquals(other.attributes, attributes) &&
-        other.interface == interface &&
-        deepEquals(other.connections, connections);
-  }
+  String toString() => '$runtimeType$_data';
 
   @override
-  int get hashCode => Object.hash(
-      snap,
-      slot,
-      Object.hashAllUnordered(
-          attributes.entries.map((e) => Object.hash(e.key, e.value))),
-      interface,
-      Object.hashAll(connections));
+  bool operator ==(Object other) => other is SnapSlot && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Information on a connection between a snap plugs and slots.
+@immutable
+@JsonSerializable()
 class SnapConnection {
   // The slot used in this connection.
-  final SnapSlot slot;
+  SnapSlot get slot => _data.slot;
 
   // Attributes for the slot.
-  final Map<String, dynamic> slotAttributes;
+  @JsonKey(name: 'slot-attrs')
+  Map<String, dynamic> get slotAttributes => _data.slotAttributes.asMap();
 
   // The plug used in this connection.
-  final SnapPlug plug;
+  SnapPlug get plug => _data.plug;
 
   // Attributes for the plug.
-  final Map<String, dynamic> plugAttributes;
+  @JsonKey(name: 'plug-attrs')
+  Map<String, dynamic> get plugAttributes => _data.plugAttributes.asMap();
 
   // The interface the connection uses.
-  final String interface;
+  String get interface => _data.interface;
 
   // True if this is manually connected.
-  final bool manual;
+  bool get manual => _data.manual;
 
-  const SnapConnection(
-      {required this.slot,
-      this.slotAttributes = const {},
-      required this.plug,
-      this.plugAttributes = const {},
-      required this.interface,
-      this.manual = false});
+  SnapConnection(
+      {required SnapSlot slot,
+      Map<String, dynamic> slotAttributes = const {},
+      required SnapPlug plug,
+      Map<String, dynamic> plugAttributes = const {},
+      required String interface,
+      bool manual = false})
+      : _data = (
+          slot: slot,
+          slotAttributes: BuiltMap(slotAttributes),
+          plug: plug,
+          plugAttributes: BuiltMap(plugAttributes),
+          interface: interface,
+          manual: manual,
+        );
 
-  factory SnapConnection._fromJson(value) {
-    return SnapConnection(
-        slot: SnapSlot._fromJson(value['slot']),
-        slotAttributes: value['slot-attrs']?.cast<String, dynamic>() ?? {},
-        plug: SnapPlug._fromJson(value['plug']),
-        plugAttributes: value['plug-attrs']?.cast<String, dynamic>() ?? {},
-        interface: value['interface'] ?? '',
-        manual: value['manual'] ?? false);
-  }
+  final ({
+    SnapSlot slot,
+    BuiltMap<String, dynamic> slotAttributes,
+    SnapPlug plug,
+    BuiltMap<String, dynamic> plugAttributes,
+    String interface,
+    bool manual,
+  }) _data;
 
-  @override
-  String toString() =>
-      '$runtimeType(slot: $slot, slotAttributes: $slotAttributes, plug: $plug, plugAttributes: $plugAttributes, interface: $interface, manual: $manual)';
+  factory SnapConnection.fromJson(Map<String, dynamic> json) =>
+      _$SnapConnectionFromJson(json);
 
-  @override
-  bool operator ==(other) {
-    if (identical(this, other)) return true;
-    final mapEquals = const DeepCollectionEquality().equals;
-
-    return other is SnapConnection &&
-        other.slot == slot &&
-        mapEquals(other.slotAttributes, slotAttributes) &&
-        other.plug == plug &&
-        mapEquals(other.plugAttributes, plugAttributes) &&
-        other.interface == interface &&
-        other.manual == manual;
-  }
+  Map<String, dynamic> toJson() => _$SnapConnectionToJson(this);
 
   @override
-  int get hashCode => Object.hash(
-      slot, slotAttributes, plug, plugAttributes, interface, manual);
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapConnection && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Response received when getting connections.
+@immutable
+@JsonSerializable()
 class SnapdConnectionsResponse {
   /// Connections that have been established.
-  final List<SnapConnection> established;
+  List<SnapConnection> get established => _data.established.asList();
 
   /// Plugs on this system.
-  final List<SnapPlug> plugs;
+  List<SnapPlug> get plugs => _data.plugs.asList();
 
   /// Slots on this system.
-  final List<SnapSlot> slots;
+  List<SnapSlot> get slots => _data.slots.asList();
 
   /// Auto-connected connections that have been manually disconnected.
-  final List<SnapConnection> undesired;
+  List<SnapConnection> get undesired => _data.undesired.asList();
 
-  const SnapdConnectionsResponse(
-      {this.established = const [],
-      this.plugs = const [],
-      this.slots = const [],
-      this.undesired = const []});
+  SnapdConnectionsResponse(
+      {List<SnapConnection> established = const [],
+      List<SnapPlug> plugs = const [],
+      List<SnapSlot> slots = const [],
+      List<SnapConnection> undesired = const []})
+      : _data = (
+          established: BuiltList(established),
+          plugs: BuiltList(plugs),
+          slots: BuiltList(slots),
+          undesired: BuiltList(undesired),
+        );
 
-  factory SnapdConnectionsResponse._fromJson(value) {
-    return SnapdConnectionsResponse(
-        established: value['established']
-                ?.map<SnapConnection>(
-                    (connection) => SnapConnection._fromJson(connection))
-                ?.toList() ??
-            <SnapConnection>[],
-        plugs: value['plugs']
-                ?.map<SnapPlug>((plug) => SnapPlug._fromJson(plug))
-                ?.toList() ??
-            <SnapPlug>[],
-        slots: value['slots']
-                ?.map<SnapSlot>((slot) => SnapSlot._fromJson(slot))
-                ?.toList() ??
-            <SnapSlot>[],
-        undesired: value['undesired']
-                ?.map<SnapConnection>(
-                    (connection) => SnapConnection._fromJson(connection))
-                ?.toList() ??
-            <SnapConnection>[]);
-  }
+  final ({
+    BuiltList<SnapConnection> established,
+    BuiltList<SnapPlug> plugs,
+    BuiltList<SnapSlot> slots,
+    BuiltList<SnapConnection> undesired,
+  }) _data;
+
+  factory SnapdConnectionsResponse.fromJson(Map<String, dynamic> json) =>
+      _$SnapdConnectionsResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapdConnectionsResponseToJson(this);
 
   @override
-  String toString() =>
-      '$runtimeType(established: $established, plugs: $plugs, slots: $slots, undesired: $undesired)';
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapdConnectionsResponse && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Gives the state of an asynchronous operation.
+@immutable
+@JsonSerializable()
 class SnapdChange {
   /// The ID of this change.
-  final String id;
+  String get id => _data.id;
 
   /// The kind of change, e.g. 'install-snap'.
-  final String kind;
+  String get kind => _data.kind;
 
   /// Short description of the change. e.g. 'Install snap "moon-buggy"'
-  final String summary;
+  String get summary => _data.summary;
 
   /// Status of the change, e.g. 'Doing'.
-  final String status;
+  String get status => _data.status;
 
   /// True when this change is complete.
-  final bool ready;
+  bool get ready => _data.ready;
 
   /// Error that occurred doing this change.
-  final String? err;
+  String? get err => _data.err;
 
   /// The time this change started.
-  final DateTime spawnTime;
+  @_SnapdDateTimeConverter()
+  DateTime get spawnTime => _data.spawnTime;
 
   /// The time this change completed.
-  final DateTime? readyTime;
+  DateTime? get readyTime => _data.readyTime;
 
   /// The tasks of this change.
-  final List<SnapdTask> tasks;
+  List<SnapdTask> get tasks => _data.tasks.asList();
 
   /// The snaps that are associated with this change.
-  final List<String> snapNames;
+  @JsonKey(
+    name: 'data',
+    toJson: _snapNamesToJson,
+    fromJson: _snapNamesFromJson,
+  )
+  List<String> get snapNames => _data.snapNames.asList();
 
-  const SnapdChange(
-      {this.id = '',
-      this.kind = '',
-      this.summary = '',
-      this.status = '',
-      this.ready = false,
-      required this.spawnTime,
-      this.readyTime,
-      this.err,
-      this.tasks = const [],
-      this.snapNames = const []});
-
-  factory SnapdChange._fromJson(value) {
-    var data = value['data'] ?? {};
-    var snapNames = data['snap-names']?.cast<String>() ?? <String>[];
-    return SnapdChange(
-        id: value['id'] ?? '',
-        kind: value['kind'] ?? '',
-        summary: value['summary'] ?? '',
-        status: value['status'] ?? '',
-        ready: value['ready'] ?? false,
-        err: value['err'],
-        spawnTime: _parseDateTime(value['spawn-time']) ?? DateTime.utc(1970),
-        readyTime: _parseDateTime(value['ready-time']),
-        tasks: value['tasks']
-                ?.map<SnapdTask>((v) => SnapdTask._fromJson(v))
-                .toList() ??
-            [],
-        snapNames: snapNames);
+  static Map<String, dynamic> _snapNamesToJson(List<String> snapNames) {
+    return {'snap-names': snapNames};
   }
 
-  @override
-  String toString() =>
-      "$runtimeType(id: $id, kind: $kind, summary: '$summary', status: $status, ready: $ready, err: $err, spawnTime: $spawnTime, readyTime: $readyTime, tasks: $tasks, snapNames: $snapNames)";
-
-  @override
-  bool operator ==(other) {
-    if (identical(this, other)) return true;
-    final deepEquals = const DeepCollectionEquality().equals;
-
-    return other is SnapdChange &&
-        other.id == id &&
-        other.kind == kind &&
-        other.summary == summary &&
-        other.status == status &&
-        other.ready == ready &&
-        other.err == err &&
-        other.spawnTime == spawnTime &&
-        other.readyTime == readyTime &&
-        deepEquals(other.tasks, tasks) &&
-        deepEquals(other.snapNames, snapNames);
+  static List<String> _snapNamesFromJson(Map<String, dynamic> json) {
+    return json['snap-names']?.cast<String>() ?? const [];
   }
 
-  @override
-  int get hashCode {
-    final deepHash = const DeepCollectionEquality().hash;
+  SnapdChange(
+      {String id = '',
+      String kind = '',
+      String summary = '',
+      String status = '',
+      bool ready = false,
+      required DateTime spawnTime,
+      DateTime? readyTime,
+      String? err,
+      List<SnapdTask> tasks = const [],
+      List<String> snapNames = const []})
+      : _data = (
+          id: id,
+          kind: kind,
+          summary: summary,
+          status: status,
+          ready: ready,
+          spawnTime: spawnTime,
+          readyTime: readyTime,
+          err: err,
+          tasks: BuiltList(tasks),
+          snapNames: BuiltList(snapNames),
+        );
 
-    return Object.hash(id, kind, summary, status, ready, err, spawnTime,
-        readyTime, deepHash(tasks), deepHash(snapNames));
-  }
+  final ({
+    String id,
+    String kind,
+    String summary,
+    String status,
+    bool ready,
+    DateTime spawnTime,
+    DateTime? readyTime,
+    String? err,
+    BuiltList<SnapdTask> tasks,
+    BuiltList<String> snapNames,
+  }) _data;
+
+  factory SnapdChange.fromJson(Map<String, dynamic> json) =>
+      _$SnapdChangeFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapdChangeToJson(this);
+
+  @override
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapdChange && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Information about a task in a [SnapdChange].
+@immutable
+@JsonSerializable()
 class SnapdTask {
   /// The ID of this task.
-  final String id;
+  String get id => _data.id;
 
   /// The kind of task, e.g. 'download-snap'install-snap'.
-  final String kind;
+  String get kind => _data.kind;
 
   /// Short description of the task. e.g. ''Download snap "moon-buggy" (12) from channel "stable"'
-  final String summary;
+  String get summary => _data.summary;
 
   /// Status of the task, e.g. 'Doing'.
-  final String status;
+  String get status => _data.status;
 
   /// Progress of this task.
-  final SnapdTaskProgress progress;
+  SnapdTaskProgress get progress => _data.progress;
 
   /// The time this task started.
-  final DateTime spawnTime;
+  @_SnapdDateTimeConverter()
+  DateTime get spawnTime => _data.spawnTime;
 
   /// The time this task completed.
-  final DateTime? readyTime;
+  DateTime? get readyTime => _data.readyTime;
 
   const SnapdTask(
-      {this.id = '',
-      this.kind = '',
-      this.summary = '',
-      this.status = '',
-      this.progress = const SnapdTaskProgress(),
-      required this.spawnTime,
-      this.readyTime});
+      {String id = '',
+      String kind = '',
+      String summary = '',
+      String status = '',
+      SnapdTaskProgress progress = const SnapdTaskProgress(),
+      required DateTime spawnTime,
+      DateTime? readyTime})
+      : _data = (
+          id: id,
+          kind: kind,
+          summary: summary,
+          status: status,
+          progress: progress,
+          spawnTime: spawnTime,
+          readyTime: readyTime,
+        );
 
-  factory SnapdTask._fromJson(value) {
-    return SnapdTask(
-        id: value['id'] ?? '',
-        kind: value['kind'] ?? '',
-        summary: value['summary'] ?? '',
-        status: value['status'] ?? '',
-        progress: value['progress'] != null
-            ? SnapdTaskProgress._fromJson(value['progress'])
-            : SnapdTaskProgress(),
-        spawnTime: _parseDateTime(value['spawn-time']) ?? DateTime.utc(1970),
-        readyTime: _parseDateTime(value['ready-time']));
-  }
+  final ({
+    String id,
+    String kind,
+    String summary,
+    String status,
+    SnapdTaskProgress progress,
+    DateTime spawnTime,
+    DateTime? readyTime,
+  }) _data;
 
-  @override
-  String toString() =>
-      "$runtimeType(id: $id, kind: $kind, summary: '$summary', status: $status, progress: $progress, spawnTime: $spawnTime, readyTime: $readyTime)";
+  factory SnapdTask.fromJson(Map<String, dynamic> json) =>
+      _$SnapdTaskFromJson(json);
 
-  @override
-  bool operator ==(other) {
-    if (identical(this, other)) return true;
-
-    return other is SnapdTask &&
-        other.id == id &&
-        other.kind == kind &&
-        other.summary == summary &&
-        other.status == status &&
-        other.progress == progress &&
-        other.spawnTime == spawnTime &&
-        other.readyTime == readyTime;
-  }
+  Map<String, dynamic> toJson() => _$SnapdTaskToJson(this);
 
   @override
-  int get hashCode =>
-      Object.hash(id, kind, summary, status, progress, spawnTime, readyTime);
+  String toString() => '$runtimeType$_data';
+
+  @override
+  bool operator ==(Object other) => other is SnapdTask && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// Progress of a [SnapdTask].
+@immutable
+@JsonSerializable()
 class SnapdTaskProgress {
   /// Optional label.
-  final String label;
+  String get label => _data.label;
 
   /// Number of progress items complete.
-  final int done;
+  int get done => _data.done;
 
   /// Total number of progress items in this task.
-  final int total;
+  int get total => _data.total;
 
-  const SnapdTaskProgress({this.label = '', this.done = 0, this.total = 0});
+  const SnapdTaskProgress({String label = '', int done = 0, int total = 0})
+      : _data = (label: label, done: done, total: total);
 
-  factory SnapdTaskProgress._fromJson(value) {
-    return SnapdTaskProgress(
-        label: value['label'] ?? '',
-        done: value['done'] ?? 0,
-        total: value['total'] ?? 0);
-  }
+  final ({String label, int done, int total}) _data;
 
-  @override
-  String toString() =>
-      "$runtimeType(label: '$label', done: $done, total: $total)";
+  factory SnapdTaskProgress.fromJson(Map<String, dynamic> json) =>
+      _$SnapdTaskProgressFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SnapdTaskProgressToJson(this);
 
   @override
-  bool operator ==(other) {
-    if (identical(this, other)) return true;
-
-    return other is SnapdTaskProgress &&
-        other.label == label &&
-        other.done == done &&
-        other.total == total;
-  }
+  String toString() => '$runtimeType$_data';
 
   @override
-  int get hashCode => Object.hash(label, done, total);
+  bool operator ==(Object other) =>
+      other is SnapdTaskProgress && other._data == _data;
+
+  @override
+  int get hashCode => _data.hashCode;
 }
 
 /// General response from snapd.
@@ -1307,7 +1308,7 @@ class SnapdClient {
   /// Gets information about the system that snapd is running on.
   Future<SnapdSystemInfoResponse> systemInfo() async {
     var result = await _getSync('/v2/system-info');
-    return SnapdSystemInfoResponse._fromJson(result);
+    return SnapdSystemInfoResponse.fromJson(result);
   }
 
   /// Gets informtion on all installed snaps.
@@ -1315,7 +1316,7 @@ class SnapdClient {
     var result = await _getSync('/v2/snaps');
     var snaps = <Snap>[];
     for (var snap in result) {
-      snaps.add(Snap._fromJson(snap));
+      snaps.add(Snap.fromJson(snap));
     }
     return snaps;
   }
@@ -1324,7 +1325,7 @@ class SnapdClient {
   Future<Snap> getSnap(String name) async {
     var encodedName = Uri.encodeComponent(name);
     var result = await _getSync('/v2/snaps/$encodedName');
-    return Snap._fromJson(result);
+    return Snap.fromJson(result);
   }
 
   /// Gets information on all installed apps.
@@ -1343,7 +1344,7 @@ class SnapdClient {
     var result = await _getSync('/v2/apps', queryParameters);
     var apps = <SnapApp>[];
     for (var app in result) {
-      apps.add(SnapApp._fromJson(app));
+      apps.add(SnapApp.fromJson(app));
     }
     return apps;
   }
@@ -1353,7 +1354,7 @@ class SnapdClient {
     var result = await _getSync('/v2/categories');
     var categories = <SnapdCategoryDetails>[];
     for (var category in result) {
-      categories.add(SnapdCategoryDetails._fromJson(category));
+      categories.add(SnapdCategoryDetails.fromJson(category));
     }
     return categories;
   }
@@ -1375,7 +1376,7 @@ class SnapdClient {
       }
     }
     var result = await _getSync('/v2/connections', queryParameters);
-    return SnapdConnectionsResponse._fromJson(result);
+    return SnapdConnectionsResponse.fromJson(result);
   }
 
   /// Refreshes the snaps given by [names].
@@ -1461,7 +1462,7 @@ class SnapdClient {
     var result = await _getSync('/v2/find', queryParameters);
     var snaps = <Snap>[];
     for (var snap in result) {
-      snaps.add(Snap._fromJson(snap));
+      snaps.add(Snap.fromJson(snap));
     }
     return snaps;
   }
@@ -1474,7 +1475,7 @@ class SnapdClient {
       request['otp'] = otp;
     }
     var result = await _postSync('/v2/login', request);
-    return SnapdLoginResponse._fromJson(result);
+    return SnapdLoginResponse.fromJson(result);
   }
 
   /// Logs out acccount with [id] from the snap store.
@@ -1560,7 +1561,7 @@ class SnapdClient {
   /// Gets the status the change with the given [id].
   Future<SnapdChange> getChange(String id) async {
     var result = await _getSync('/v2/changes/$id');
-    return SnapdChange._fromJson(result);
+    return SnapdChange.fromJson(result);
   }
 
   /// Get changes that have occurred / are occurring on the snap daemon.
@@ -1585,7 +1586,7 @@ class SnapdClient {
     var result = await _getSync('/v2/changes', queryParameters);
     var changes = <SnapdChange>[];
     for (var change in result) {
-      changes.add(SnapdChange._fromJson(change));
+      changes.add(SnapdChange.fromJson(change));
     }
     return changes;
   }
@@ -1594,7 +1595,7 @@ class SnapdClient {
   Future<SnapdChange> abortChange(String id) async {
     var queryParameters = {'action': 'abort'};
     var result = await _postSync('/v2/changes/$id', queryParameters);
-    return SnapdChange._fromJson(result);
+    return SnapdChange.fromJson(result);
   }
 
   /// Terminates all active connections. If a client remains unclosed, the Dart process may not terminate.

--- a/lib/src/snapd_client.g.dart
+++ b/lib/src/snapd_client.g.dart
@@ -1,0 +1,451 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'snapd_client.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SnapApp _$SnapAppFromJson(Map<String, dynamic> json) => SnapApp(
+      snap: json['snap'] as String?,
+      name: json['name'] as String,
+      desktopFile: json['desktop-file'] as String?,
+      daemon: json['daemon'] as String?,
+      enabled: json['enabled'] as bool? ?? true,
+      active: json['active'] as bool? ?? true,
+      commonId: json['common-id'] as String?,
+    );
+
+Map<String, dynamic> _$SnapAppToJson(SnapApp instance) => <String, dynamic>{
+      'snap': instance.snap,
+      'name': instance.name,
+      'desktop-file': instance.desktopFile,
+      'daemon': instance.daemon,
+      'enabled': instance.enabled,
+      'active': instance.active,
+      'common-id': instance.commonId,
+    };
+
+SnapCategory _$SnapCategoryFromJson(Map<String, dynamic> json) => SnapCategory(
+      name: json['name'] as String,
+      featured: json['featured'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$SnapCategoryToJson(SnapCategory instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'featured': instance.featured,
+    };
+
+SnapdCategoryDetails _$SnapdCategoryDetailsFromJson(
+        Map<String, dynamic> json) =>
+    SnapdCategoryDetails(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$SnapdCategoryDetailsToJson(
+        SnapdCategoryDetails instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };
+
+SnapChannel _$SnapChannelFromJson(Map<String, dynamic> json) => SnapChannel(
+      confinement:
+          $enumDecodeNullable(_$SnapConfinementEnumMap, json['confinement']) ??
+              SnapConfinement.unknown,
+      releasedAt: const _SnapdDateTimeConverter()
+          .fromJson(json['released-at'] as String?),
+      revision: json['revision'] as String? ?? '',
+      size: json['size'] as int? ?? 0,
+      version: json['version'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$SnapChannelToJson(SnapChannel instance) =>
+    <String, dynamic>{
+      'confinement': _$SnapConfinementEnumMap[instance.confinement]!,
+      'released-at':
+          const _SnapdDateTimeConverter().toJson(instance.releasedAt),
+      'revision': instance.revision,
+      'size': instance.size,
+      'version': instance.version,
+    };
+
+const _$SnapConfinementEnumMap = {
+  SnapConfinement.unknown: 'unknown',
+  SnapConfinement.strict: 'strict',
+  SnapConfinement.devmode: 'devmode',
+  SnapConfinement.classic: 'classic',
+};
+
+SnapPublisher _$SnapPublisherFromJson(Map<String, dynamic> json) =>
+    SnapPublisher(
+      id: json['id'] as String? ?? '',
+      username: json['username'] as String? ?? '',
+      displayName: json['display-name'] as String? ?? '',
+      validation: json['validation'] as String?,
+    );
+
+Map<String, dynamic> _$SnapPublisherToJson(SnapPublisher instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'username': instance.username,
+      'display-name': instance.displayName,
+      'validation': instance.validation,
+    };
+
+SnapMedia _$SnapMediaFromJson(Map<String, dynamic> json) => SnapMedia(
+      type: json['type'] as String,
+      url: json['url'] as String,
+      width: json['width'] as int?,
+      height: json['height'] as int?,
+    );
+
+Map<String, dynamic> _$SnapMediaToJson(SnapMedia instance) => <String, dynamic>{
+      'type': instance.type,
+      'url': instance.url,
+      'width': instance.width,
+      'height': instance.height,
+    };
+
+Snap _$SnapFromJson(Map<String, dynamic> json) => Snap(
+      apps: (json['apps'] as List<dynamic>?)
+              ?.map((e) => SnapApp.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      base: json['base'] as String?,
+      categories: (json['categories'] as List<dynamic>?)
+              ?.map((e) => SnapCategory.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      channel: json['channel'] as String? ?? '',
+      channels: (json['channels'] as Map<String, dynamic>?)?.map(
+            (k, e) =>
+                MapEntry(k, SnapChannel.fromJson(e as Map<String, dynamic>)),
+          ) ??
+          const {},
+      commonIds: (json['common-ids'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      confinement:
+          $enumDecodeNullable(_$SnapConfinementEnumMap, json['confinement']) ??
+              SnapConfinement.unknown,
+      contact: json['contact'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      devmode: json['devmode'] as bool? ?? false,
+      downloadSize: json['download-size'] as int?,
+      hold:
+          json['hold'] == null ? null : DateTime.parse(json['hold'] as String),
+      id: json['id'] as String? ?? '',
+      installDate: json['install-date'] == null
+          ? null
+          : DateTime.parse(json['install-date'] as String),
+      installedSize: json['installed-size'] as int?,
+      jailmode: json['jailmode'] as bool? ?? false,
+      license: json['license'] as String?,
+      media: (json['media'] as List<dynamic>?)
+              ?.map((e) => SnapMedia.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      mountedFrom: json['mounted-from'] as String?,
+      name: json['name'] as String,
+      private: json['private'] as bool? ?? false,
+      publisher: json['publisher'] == null
+          ? null
+          : SnapPublisher.fromJson(json['publisher'] as Map<String, dynamic>),
+      revision: json['revision'] as String? ?? '',
+      status: $enumDecodeNullable(_$SnapStatusEnumMap, json['status']) ??
+          SnapStatus.unknown,
+      storeUrl: json['store-url'] as String?,
+      summary: json['summary'] as String? ?? '',
+      title: json['title'] as String?,
+      trackingChannel: json['tracking-channel'] as String?,
+      tracks: (json['tracks'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      type: json['type'] as String? ?? '',
+      version: json['version'] as String? ?? '',
+      website: json['website'] as String?,
+    );
+
+Map<String, dynamic> _$SnapToJson(Snap instance) => <String, dynamic>{
+      'apps': instance.apps.map((e) => e.toJson()).toList(),
+      'base': instance.base,
+      'categories': instance.categories.map((e) => e.toJson()).toList(),
+      'channel': instance.channel,
+      'channels': instance.channels.map((k, e) => MapEntry(k, e.toJson())),
+      'common-ids': instance.commonIds,
+      'confinement': _$SnapConfinementEnumMap[instance.confinement]!,
+      'contact': instance.contact,
+      'description': instance.description,
+      'devmode': instance.devmode,
+      'download-size': instance.downloadSize,
+      'hold': instance.hold?.toIso8601String(),
+      'id': instance.id,
+      'install-date': instance.installDate?.toIso8601String(),
+      'installed-size': instance.installedSize,
+      'jailmode': instance.jailmode,
+      'license': instance.license,
+      'media': instance.media.map((e) => e.toJson()).toList(),
+      'mounted-from': instance.mountedFrom,
+      'name': instance.name,
+      'private': instance.private,
+      'publisher': instance.publisher?.toJson(),
+      'revision': instance.revision,
+      'status': _$SnapStatusEnumMap[instance.status]!,
+      'store-url': instance.storeUrl,
+      'summary': instance.summary,
+      'title': instance.title,
+      'tracking-channel': instance.trackingChannel,
+      'tracks': instance.tracks,
+      'type': instance.type,
+      'version': instance.version,
+      'website': instance.website,
+    };
+
+const _$SnapStatusEnumMap = {
+  SnapStatus.unknown: 'unknown',
+  SnapStatus.available: 'available',
+  SnapStatus.priced: 'priced',
+  SnapStatus.installed: 'installed',
+  SnapStatus.active: 'active',
+};
+
+SnapdSystemInfoResponse _$SnapdSystemInfoResponseFromJson(
+        Map<String, dynamic> json) =>
+    SnapdSystemInfoResponse(
+      architecture: json['architecture'] as String? ?? '',
+      buildId: json['build-id'] as String? ?? '',
+      confinement:
+          $enumDecodeNullable(_$SnapConfinementEnumMap, json['confinement']) ??
+              SnapConfinement.unknown,
+      kernelVersion: json['kernel-version'] as String? ?? '',
+      managed: json['managed'] as bool? ?? false,
+      onClassic: json['on-classic'] as bool? ?? false,
+      refresh: SnapdSystemRefreshInfo.fromJson(
+          json['refresh'] as Map<String, dynamic>),
+      series: json['series'] as String? ?? '',
+      systemMode: json['system-mode'] as String? ?? '',
+      version: json['version'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$SnapdSystemInfoResponseToJson(
+        SnapdSystemInfoResponse instance) =>
+    <String, dynamic>{
+      'architecture': instance.architecture,
+      'build-id': instance.buildId,
+      'confinement': _$SnapConfinementEnumMap[instance.confinement]!,
+      'kernel-version': instance.kernelVersion,
+      'managed': instance.managed,
+      'on-classic': instance.onClassic,
+      'refresh': instance.refresh.toJson(),
+      'series': instance.series,
+      'system-mode': instance.systemMode,
+      'version': instance.version,
+    };
+
+SnapdSystemRefreshInfo _$SnapdSystemRefreshInfoFromJson(
+        Map<String, dynamic> json) =>
+    SnapdSystemRefreshInfo(
+      last:
+          json['last'] == null ? null : DateTime.parse(json['last'] as String),
+      next: const _SnapdDateTimeConverter().fromJson(json['next'] as String?),
+    );
+
+Map<String, dynamic> _$SnapdSystemRefreshInfoToJson(
+        SnapdSystemRefreshInfo instance) =>
+    <String, dynamic>{
+      'last': instance.last?.toIso8601String(),
+      'next': const _SnapdDateTimeConverter().toJson(instance.next),
+    };
+
+SnapdLoginResponse _$SnapdLoginResponseFromJson(Map<String, dynamic> json) =>
+    SnapdLoginResponse(
+      id: json['id'] as int,
+      username: json['username'] as String?,
+      email: json['email'] as String?,
+      macaroon: json['macaroon'] as String?,
+      discharges: (json['discharges'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      sshKeys: (json['ssh-keys'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$SnapdLoginResponseToJson(SnapdLoginResponse instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'username': instance.username,
+      'email': instance.email,
+      'macaroon': instance.macaroon,
+      'discharges': instance.discharges,
+      'ssh-keys': instance.sshKeys,
+    };
+
+SnapPlug _$SnapPlugFromJson(Map<String, dynamic> json) => SnapPlug(
+      snap: json['snap'] as String,
+      plug: json['plug'] as String,
+      attributes: json['attrs'] as Map<String, dynamic>? ?? const {},
+      interface: json['interface'] as String?,
+      connections: (json['connections'] as List<dynamic>?)
+              ?.map((e) => SnapSlot.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$SnapPlugToJson(SnapPlug instance) => <String, dynamic>{
+      'snap': instance.snap,
+      'plug': instance.plug,
+      'attrs': instance.attributes,
+      'interface': instance.interface,
+      'connections': instance.connections.map((e) => e.toJson()).toList(),
+    };
+
+SnapSlot _$SnapSlotFromJson(Map<String, dynamic> json) => SnapSlot(
+      snap: json['snap'] as String,
+      slot: json['slot'] as String,
+      attributes: json['attrs'] as Map<String, dynamic>? ?? const {},
+      interface: json['interface'] as String?,
+      connections: (json['connections'] as List<dynamic>?)
+              ?.map((e) => SnapPlug.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$SnapSlotToJson(SnapSlot instance) => <String, dynamic>{
+      'snap': instance.snap,
+      'slot': instance.slot,
+      'attrs': instance.attributes,
+      'interface': instance.interface,
+      'connections': instance.connections.map((e) => e.toJson()).toList(),
+    };
+
+SnapConnection _$SnapConnectionFromJson(Map<String, dynamic> json) =>
+    SnapConnection(
+      slot: SnapSlot.fromJson(json['slot'] as Map<String, dynamic>),
+      slotAttributes: json['slot-attrs'] as Map<String, dynamic>? ?? const {},
+      plug: SnapPlug.fromJson(json['plug'] as Map<String, dynamic>),
+      plugAttributes: json['plug-attrs'] as Map<String, dynamic>? ?? const {},
+      interface: json['interface'] as String,
+      manual: json['manual'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$SnapConnectionToJson(SnapConnection instance) =>
+    <String, dynamic>{
+      'slot': instance.slot.toJson(),
+      'slot-attrs': instance.slotAttributes,
+      'plug': instance.plug.toJson(),
+      'plug-attrs': instance.plugAttributes,
+      'interface': instance.interface,
+      'manual': instance.manual,
+    };
+
+SnapdConnectionsResponse _$SnapdConnectionsResponseFromJson(
+        Map<String, dynamic> json) =>
+    SnapdConnectionsResponse(
+      established: (json['established'] as List<dynamic>?)
+              ?.map((e) => SnapConnection.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      plugs: (json['plugs'] as List<dynamic>?)
+              ?.map((e) => SnapPlug.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      slots: (json['slots'] as List<dynamic>?)
+              ?.map((e) => SnapSlot.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      undesired: (json['undesired'] as List<dynamic>?)
+              ?.map((e) => SnapConnection.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$SnapdConnectionsResponseToJson(
+        SnapdConnectionsResponse instance) =>
+    <String, dynamic>{
+      'established': instance.established.map((e) => e.toJson()).toList(),
+      'plugs': instance.plugs.map((e) => e.toJson()).toList(),
+      'slots': instance.slots.map((e) => e.toJson()).toList(),
+      'undesired': instance.undesired.map((e) => e.toJson()).toList(),
+    };
+
+SnapdChange _$SnapdChangeFromJson(Map<String, dynamic> json) => SnapdChange(
+      id: json['id'] as String? ?? '',
+      kind: json['kind'] as String? ?? '',
+      summary: json['summary'] as String? ?? '',
+      status: json['status'] as String? ?? '',
+      ready: json['ready'] as bool? ?? false,
+      spawnTime: const _SnapdDateTimeConverter()
+          .fromJson(json['spawn-time'] as String?),
+      readyTime: json['ready-time'] == null
+          ? null
+          : DateTime.parse(json['ready-time'] as String),
+      err: json['err'] as String?,
+      tasks: (json['tasks'] as List<dynamic>?)
+              ?.map((e) => SnapdTask.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      snapNames: json['data'] == null
+          ? const []
+          : SnapdChange._snapNamesFromJson(
+              json['data'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$SnapdChangeToJson(SnapdChange instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'kind': instance.kind,
+      'summary': instance.summary,
+      'status': instance.status,
+      'ready': instance.ready,
+      'err': instance.err,
+      'spawn-time': const _SnapdDateTimeConverter().toJson(instance.spawnTime),
+      'ready-time': instance.readyTime?.toIso8601String(),
+      'tasks': instance.tasks.map((e) => e.toJson()).toList(),
+      'data': SnapdChange._snapNamesToJson(instance.snapNames),
+    };
+
+SnapdTask _$SnapdTaskFromJson(Map<String, dynamic> json) => SnapdTask(
+      id: json['id'] as String? ?? '',
+      kind: json['kind'] as String? ?? '',
+      summary: json['summary'] as String? ?? '',
+      status: json['status'] as String? ?? '',
+      progress: json['progress'] == null
+          ? const SnapdTaskProgress()
+          : SnapdTaskProgress.fromJson(
+              json['progress'] as Map<String, dynamic>),
+      spawnTime: const _SnapdDateTimeConverter()
+          .fromJson(json['spawn-time'] as String?),
+      readyTime: json['ready-time'] == null
+          ? null
+          : DateTime.parse(json['ready-time'] as String),
+    );
+
+Map<String, dynamic> _$SnapdTaskToJson(SnapdTask instance) => <String, dynamic>{
+      'id': instance.id,
+      'kind': instance.kind,
+      'summary': instance.summary,
+      'status': instance.status,
+      'progress': instance.progress.toJson(),
+      'spawn-time': const _SnapdDateTimeConverter().toJson(instance.spawnTime),
+      'ready-time': instance.readyTime?.toIso8601String(),
+    };
+
+SnapdTaskProgress _$SnapdTaskProgressFromJson(Map<String, dynamic> json) =>
+    SnapdTaskProgress(
+      label: json['label'] as String? ?? '',
+      done: json['done'] as int? ?? 0,
+      total: json['total'] as int? ?? 0,
+    );
+
+Map<String, dynamic> _$SnapdTaskProgressToJson(SnapdTaskProgress instance) =>
+    <String, dynamic>{
+      'label': instance.label,
+      'done': instance.done,
+      'total': instance.total,
+    };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,17 +7,20 @@ description:
 homepage: https://github.com/canonical/snapd.dart
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 platforms:
   linux:
 
 dependencies:
-  collection: ^1.15.0
+  built_collection: ^5.1.0
+  json_annotation: ^4.8.1
+  meta: ^1.8.0
   path: ^1.8.0
 
 dev_dependencies:
+  build_runner: ^2.4.6
+  json_serializable: ^6.7.0
   lints: ^2.0.0
   test: ^1.16.8
   test_cov: ^1.0.1
-

--- a/test/snapd_test.dart
+++ b/test/snapd_test.dart
@@ -471,7 +471,7 @@ class MockSnapdServer {
     this.buildId = '',
     this.categories = const [],
     List<MockChange> changes = const [],
-    this.confinement = '',
+    this.confinement = 'unknown',
     this.kernelVersion = '',
     this.managed = false,
     this.onClassic = false,
@@ -1177,15 +1177,15 @@ void main() {
     expect(info.kernelVersion, equals('5.11.0'));
     expect(info.managed, isTrue);
     expect(info.onClassic, isTrue);
-    expect(info.refreshLast, equals(DateTime.utc(2022, 5, 28, 20, 10)));
-    expect(info.refreshNext, equals(DateTime.utc(2022, 5, 29, 1, 18)));
+    expect(info.refresh.last, equals(DateTime.utc(2022, 5, 28, 20, 10)));
+    expect(info.refresh.next, equals(DateTime.utc(2022, 5, 29, 1, 18)));
     expect(info.series, equals('16'));
     expect(info.systemMode, equals('run'));
     expect(info.version, equals('2.49'));
     expect(
         info.toString(),
         equals(
-            'SnapdSystemInfoResponse(architecture: amd64, buildId: 2a0c915752b1c3c5dd7980220cd246876fb0a510, confinement: SnapConfinement.strict, kernelVersion: 5.11.0, managed: true, onClassic: true, refreshLast: 2022-05-28 20:10:00.000Z, refreshNext: 2022-05-29 01:18:00.000Z, series: 16, systemMode: run, version: 2.49)'));
+            'SnapdSystemInfoResponse(architecture: amd64, buildId: 2a0c915752b1c3c5dd7980220cd246876fb0a510, confinement: SnapConfinement.strict, kernelVersion: 5.11.0, managed: true, onClassic: true, refresh: SnapdSystemRefreshInfo(last: 2022-05-28 20:10:00.000Z, next: 2022-05-29 01:18:00.000Z), series: 16, systemMode: run, version: 2.49)'));
   });
 
   test('user agent', () async {
@@ -1281,7 +1281,7 @@ void main() {
     expect(
         response.toString(),
         equals(
-            'SnapdLoginResponse(id: 42, username: admin, email: admin@example.com, macaroon: macaroon, discharges: [discharge1, discharge2])'));
+            'SnapdLoginResponse(discharges: [discharge1, discharge2], email: admin@example.com, id: 42, macaroon: macaroon, sshKeys: [key1, key2], username: admin)'));
   });
 
   test('login - otp', () async {
@@ -1535,7 +1535,7 @@ void main() {
     expect(
         snap.toString(),
         equals(
-            "Snap(apps: [], base: null, categories: [], channel: , channels: {}, commonIds: [], confinement: SnapConfinement.unknown, contact: , description: 'Hello\\nSalut\\nHola', devmode: false, downloadSize: null, hold: null, id: QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV, installDate: null, installedSize: null, jailmode: false, license: null, media: [], mountedFrom: null, name: hello, private: false, publisher: null, revision: 42, status: SnapStatus.unknown, storeUrl: null, summary: 'Hello is an app', title: 'Hello', trackingChannel: null, tracks: [], type: app, version: 1.2, website: null)"));
+            'Snap(apps: [], base: null, categories: [], channel: , channels: {}, commonIds: [], confinement: SnapConfinement.unknown, contact: , description: Hello\nSalut\nHola, devmode: false, downloadSize: null, hold: null, id: QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV, installDate: null, installedSize: null, jailmode: false, license: null, media: [], mountedFrom: null, name: hello, private: false, publisher: null, revision: 42, status: SnapStatus.unknown, storeUrl: null, summary: Hello is an app, title: Hello, trackingChannel: null, tracks: [], type: app, version: 1.2, website: null)'));
   });
 
   test('snap optional properties', () async {
@@ -1684,7 +1684,7 @@ void main() {
     expect(
         snap.toString(),
         equals(
-            "Snap(apps: [SnapApp(snap: hello, name: hello1, desktopFile: null, daemon: null, enabled: true, active: true, commonId: null), SnapApp(snap: hello, name: hello2, desktopFile: null, daemon: null, enabled: true, active: true, commonId: null)], base: core20, categories: [SnapCategory(name: category1, featured: false), SnapCategory(name: category2, featured: true)], channel: stable, channels: {latest/stable: SnapChannel(confinement: SnapConfinement.strict, releasedAt: 2022-05-02 21:24:15.330374Z, revision: 42, size: 123456, version: 1.2), insider/stable: SnapChannel(confinement: SnapConfinement.classic, releasedAt: 2022-04-26 12:54:32.578086Z, revision: 43, size: 888888, version: 1.3)}, commonIds: [com.example.Hello, com.example.Hallo], confinement: SnapConfinement.classic, contact: hello@example.com, description: 'Hello\\nSalut\\nHola', devmode: true, downloadSize: 123456, hold: 2315-06-19 13:00:37.186885Z, id: QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV, installDate: 2022-05-13 09:51:03.920998Z, installedSize: 654321, jailmode: true, license: GPL-3, media: [SnapMedia(type: icon, url: http://example.com/hello-icon.png, width: null, height: null), SnapMedia(type: screenshot, url: http://example.com/hello-screenshot.jpg, width: 1024, height: 768)], mountedFrom: /var/lib/snapd/snaps/hello_1.2.snap, name: hello, private: true, publisher: SnapPublisher(id: JvtzsxbsHivZLdvzrt0iqW529riGLfXJ, username: publisher, displayName: Publisher, validation: verified), revision: 42, status: SnapStatus.available, storeUrl: https://snapcraft.io/hello, summary: 'Hello is an app', title: 'Hello', trackingChannel: latest/stable, tracks: [latest, insider], type: app, version: 1.2, website: http://example.com/hello)"));
+            'Snap(apps: [SnapApp(active: true, commonId: null, daemon: null, desktopFile: null, enabled: true, name: hello1, snap: hello), SnapApp(active: true, commonId: null, daemon: null, desktopFile: null, enabled: true, name: hello2, snap: hello)], base: core20, categories: [SnapCategory(name: category1, featured: false), SnapCategory(name: category2, featured: true)], channel: stable, channels: {latest/stable: SnapChannel((confinement: SnapConfinement.strict, releasedAt: 2022-05-02 21:24:15.330374Z, revision: 42, size: 123456, version: 1.2)), insider/stable: SnapChannel((confinement: SnapConfinement.classic, releasedAt: 2022-04-26 12:54:32.578086Z, revision: 43, size: 888888, version: 1.3))}, commonIds: [com.example.Hello, com.example.Hallo], confinement: SnapConfinement.classic, contact: hello@example.com, description: Hello\nSalut\nHola, devmode: true, downloadSize: 123456, hold: 2315-06-19 13:00:37.186885Z, id: QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV, installDate: 2022-05-13 09:51:03.920998Z, installedSize: 654321, jailmode: true, license: GPL-3, media: [SnapMedia(height: null, type: icon, url: http://example.com/hello-icon.png, width: null), SnapMedia(height: 768, type: screenshot, url: http://example.com/hello-screenshot.jpg, width: 1024)], mountedFrom: /var/lib/snapd/snaps/hello_1.2.snap, name: hello, private: true, publisher: SnapPublisher(displayName: Publisher, id: JvtzsxbsHivZLdvzrt0iqW529riGLfXJ, username: publisher, validation: verified), revision: 42, status: SnapStatus.available, storeUrl: https://snapcraft.io/hello, summary: Hello is an app, title: Hello, trackingChannel: latest/stable, tracks: [latest, insider], type: app, version: 1.2, website: http://example.com/hello)'));
   });
 
   test('categories', () async {
@@ -1764,7 +1764,7 @@ void main() {
     expect(
         response.toString(),
         equals(
-            'SnapdConnectionsResponse(established: [SnapConnection(slot: SnapSlot(snap: test3, slot: slot3), slotAttributes: {}, plug: SnapPlug(snap: test1, plug: plug1), plugAttributes: {}, interface: interface1, manual: false)], plugs: [SnapPlug(snap: test1, plug: plug1, interface: interface1, connections: [SnapSlot(snap: test3, slot: slot3)])], slots: [SnapSlot(snap: test3, slot: slot3, interface: interface1, connections: [SnapPlug(snap: test1, plug: plug1)])], undesired: [])'));
+            'SnapdConnectionsResponse(established: [SnapConnection(interface: interface1, manual: false, plug: SnapPlug(attributes: {}, connections: [], interface: null, plug: plug1, snap: test1), plugAttributes: {}, slot: SnapSlot(attributes: {}, connections: [], interface: null, slot: slot3, snap: test3), slotAttributes: {})], plugs: [SnapPlug(attributes: {}, connections: [SnapSlot(attributes: {}, connections: [], interface: null, slot: slot3, snap: test3)], interface: interface1, plug: plug1, snap: test1)], slots: [SnapSlot(attributes: {}, connections: [SnapPlug(attributes: {}, connections: [], interface: null, plug: plug1, snap: test1)], interface: interface1, slot: slot3, snap: test3)], undesired: [])'));
   });
 
   test('connection attributes', () async {
@@ -1809,11 +1809,11 @@ void main() {
     expect(
         response.plugs.toString(),
         equals(
-            '[SnapPlug(snap: test1, plug: plug1, attributes: {plug-attribute1: plug-attribute-value1}, interface: interface1)]'));
+            '[SnapPlug(attributes: {plug-attribute1: plug-attribute-value1}, connections: [], interface: interface1, plug: plug1, snap: test1)]'));
     expect(
         response.slots.toString(),
         equals(
-            '[SnapSlot(snap: test2, slot: slot1, attributes: {slot-attribute1: slot-attribute-value1}, interface: interface1)]'));
+            '[SnapSlot(attributes: {slot-attribute1: slot-attribute-value1}, connections: [], interface: interface1, slot: slot1, snap: test2)]'));
   });
 
   test('connections - all', () async {
@@ -2025,7 +2025,7 @@ void main() {
     expect(
         change.toString(),
         equals(
-            "SnapdChange(id: 0, kind: , summary: '', status: , ready: true, err: null, spawnTime: 2022-04-28 13:56:00.000Z, readyTime: null, tasks: [SnapdTask(id: 0, kind: , summary: '', status: , progress: SnapdTaskProgress(label: '', done: 10, total: 10), spawnTime: 1970-01-01 00:00:00.000Z, readyTime: null)], snapNames: [test1, test3])"));
+            'SnapdChange(err: null, id: 0, kind: , ready: true, readyTime: null, snapNames: [test1, test3], spawnTime: 2022-04-28 13:56:00.000Z, status: , summary: , tasks: [SnapdTask(id: 0, kind: , progress: SnapdTaskProgress(done: 10, label: , total: 10), readyTime: null, spawnTime: 1970-01-01 00:00:00.000Z, status: , summary: )])'));
   });
 
   test('disconnect', () async {


### PR DESCRIPTION
While waiting for proper [data classes](https://github.com/dart-lang/language/issues/314) in Dart, this PR makes use of Dart 3 [records](https://dart.dev/language/records) that come with built-in equality (primitive, not deep) with help of [json_serializable](https://pub.dev/packages/json_serializable) for JSON conversion and [built_collection](https://pub.dev/packages/built_collection) for immutable and comparable collections. Both are mature, 5+ years old packages maintained by Google.

Close: #90
Close: #92