### PR TITLE
fix: add missing equality to SnapdChange/Task/Progress

### DIFF
--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -877,6 +877,32 @@ class SnapdChange {
   @override
   String toString() =>
       "$runtimeType(id: $id, kind: $kind, summary: '$summary', status: $status, ready: $ready, err: $err, spawnTime: $spawnTime, readyTime: $readyTime, tasks: $tasks, snapNames: $snapNames)";
+
+  @override
+  bool operator ==(other) {
+    if (identical(this, other)) return true;
+    final deepEquals = const DeepCollectionEquality().equals;
+
+    return other is SnapdChange &&
+        other.id == id &&
+        other.kind == kind &&
+        other.summary == summary &&
+        other.status == status &&
+        other.ready == ready &&
+        other.err == err &&
+        other.spawnTime == spawnTime &&
+        other.readyTime == readyTime &&
+        deepEquals(other.tasks, tasks) &&
+        deepEquals(other.snapNames, snapNames);
+  }
+
+  @override
+  int get hashCode {
+    final deepHash = const DeepCollectionEquality().hash;
+
+    return Object.hash(id, kind, summary, status, ready, err, spawnTime,
+        readyTime, deepHash(tasks), deepHash(snapNames));
+  }
 }
 
 /// Information about a task in a [SnapdChange].
@@ -927,6 +953,24 @@ class SnapdTask {
   @override
   String toString() =>
       "$runtimeType(id: $id, kind: $kind, summary: '$summary', status: $status, progress: $progress, spawnTime: $spawnTime, readyTime: $readyTime)";
+
+  @override
+  bool operator ==(other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapdTask &&
+        other.id == id &&
+        other.kind == kind &&
+        other.summary == summary &&
+        other.status == status &&
+        other.progress == progress &&
+        other.spawnTime == spawnTime &&
+        other.readyTime == readyTime;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, kind, summary, status, progress, spawnTime, readyTime);
 }
 
 /// Progress of a [SnapdTask].
@@ -952,6 +996,19 @@ class SnapdTaskProgress {
   @override
   String toString() =>
       "$runtimeType(label: '$label', done: $done, total: $total)";
+
+  @override
+  bool operator ==(other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapdTaskProgress &&
+        other.label == label &&
+        other.done == done &&
+        other.total == total;
+  }
+
+  @override
+  int get hashCode => Object.hash(label, done, total);
 }
 
 /// General response from snapd.

--- a/test/snapd_test.dart
+++ b/test/snapd_test.dart
@@ -2517,7 +2517,19 @@ void main() {
           readyTime: '2022-06-07T09:21:22.550329668Z',
           error: 'Error',
           ready: false,
-          snapNames: ['snap1', 'snap2']),
+          snapNames: [
+            'snap1',
+            'snap2'
+          ],
+          tasks: [
+            MockTask(
+                id: '11',
+                kind: 'task-kind',
+                progress:
+                    MockTaskProgress(label: 'Progress', done: 22, total: 33),
+                summary: 'Task',
+                status: 'Doing')
+          ]),
       MockChange(id: '2', ready: false, snapNames: ['snap2', 'snap3']),
       MockChange(id: '3', ready: true, snapNames: ['snap3', 'snap4'])
     ]);
@@ -2534,17 +2546,32 @@ void main() {
     // Default behaviour is to get in progress changes.
     var changes = await client.getChanges();
     expect(changes, hasLength(2));
-    expect(changes[0].id, equals('1'));
-    expect(changes[0].kind, equals('change-kind'));
-    expect(changes[0].summary, equals('Summary'));
-    expect(changes[0].status, equals('Doing'));
-    expect(changes[0].spawnTime,
-        equals(DateTime.utc(2022, 6, 7, 9, 21, 22, 311, 860)));
-    expect(changes[0].readyTime,
-        equals(DateTime.utc(2022, 6, 7, 9, 21, 22, 550, 329)));
-    expect(changes[0].err, equals('Error'));
-    expect(changes[0].ready, isFalse);
-    expect(changes[0].snapNames, equals(['snap1', 'snap2']));
+    expect(
+        changes[0],
+        equals(SnapdChange(
+            id: '1',
+            kind: 'change-kind',
+            summary: 'Summary',
+            status: 'Doing',
+            spawnTime: DateTime.utc(2022, 6, 7, 9, 21, 22, 311, 860),
+            readyTime: DateTime.utc(2022, 6, 7, 9, 21, 22, 550, 329),
+            err: 'Error',
+            ready: false,
+            snapNames: [
+              'snap1',
+              'snap2'
+            ],
+            tasks: [
+              SnapdTask(
+                id: '11',
+                kind: 'task-kind',
+                summary: 'Task',
+                status: 'Doing',
+                progress:
+                    SnapdTaskProgress(label: 'Progress', done: 22, total: 33),
+                spawnTime: DateTime.utc(1970, 1, 1),
+              )
+            ])));
     expect(changes[1].id, equals('2'));
 
     var allChanges = await client.getChanges(filter: SnapdChangeFilter.all);


### PR DESCRIPTION
Fixes a small part of #90. This is the bare minimum to be able to monitor snapd changes and tasks:

```dart
Stream.periodic(interval, (_) => client.getChange(id)).distinct()
```

Without deep equality, every SnapdChange instance slips through as a distinct change even if nothing had changed.