### PR TITLE
fix: add missing equality (Snap/App/Category/Channel/Media/Publisher)

### DIFF
--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -107,6 +107,24 @@ class SnapApp {
   @override
   String toString() =>
       '$runtimeType(snap: $snap, name: $name, desktopFile: $desktopFile, daemon: $daemon, enabled: $enabled, active: $active, commonId: $commonId)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapApp &&
+        other.snap == snap &&
+        other.name == name &&
+        other.desktopFile == desktopFile &&
+        other.daemon == daemon &&
+        other.enabled == enabled &&
+        other.active == active &&
+        other.commonId == commonId;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(snap, name, desktopFile, daemon, enabled, active, commonId);
 }
 
 /// Describes an category this snap is part of.
@@ -126,6 +144,18 @@ class SnapCategory {
 
   @override
   String toString() => '$runtimeType(name: $name, featured: $featured)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapCategory &&
+        other.name == name &&
+        other.featured == featured;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, featured);
 }
 
 /// Describes a snap category.
@@ -141,6 +171,16 @@ class SnapdCategoryDetails {
 
   @override
   String toString() => '$runtimeType(name: $name)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapdCategoryDetails && other.name == name;
+  }
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 /// Describes a channel available for a snap.
@@ -179,6 +219,22 @@ class SnapChannel {
   @override
   String toString() =>
       '$runtimeType(confinement: $confinement, releasedAt: $releasedAt, revision: $revision, size: $size, version: $version)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapChannel &&
+        other.confinement == confinement &&
+        other.releasedAt == releasedAt &&
+        other.revision == revision &&
+        other.size == size &&
+        other.version == version;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(confinement, releasedAt, revision, size, version);
 }
 
 /// Describes a snap publisher.
@@ -212,6 +268,20 @@ class SnapPublisher {
   @override
   String toString() =>
       '$runtimeType(id: $id, username: $username, displayName: $displayName, validation: $validation)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapPublisher &&
+        other.id == id &&
+        other.username == username &&
+        other.displayName == displayName &&
+        other.validation == validation;
+  }
+
+  @override
+  int get hashCode => Object.hash(id, username, displayName, validation);
 }
 
 /// Describes a piece of media associated with a snap.
@@ -242,6 +312,20 @@ class SnapMedia {
   @override
   String toString() =>
       '$runtimeType(type: $type, url: $url, width: $width, height: $height)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SnapMedia &&
+        other.type == type &&
+        other.url == url &&
+        other.width == width &&
+        other.height == height;
+  }
+
+  @override
+  int get hashCode => Object.hash(type, url, width, height);
 }
 
 /// Describes a snap package.
@@ -430,6 +514,85 @@ class Snap {
   @override
   String toString() =>
       "$runtimeType(apps: $apps, base: $base, categories: $categories, channel: $channel, channels: $channels, commonIds: $commonIds, confinement: $confinement, contact: $contact, description: '${description.replaceAll('\n', '\\n')}', devmode: $devmode, downloadSize: $downloadSize, hold: $hold, id: $id, installDate: $installDate, installedSize: $installedSize, jailmode: $jailmode, license: $license, media: $media, mountedFrom: $mountedFrom, name: $name, private: $private, publisher: $publisher, revision: $revision, status: $status, storeUrl: $storeUrl, summary: '$summary', title: '$title', trackingChannel: $trackingChannel, tracks: $tracks, type: $type, version: $version, website: $website)";
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    final deepEquals = const DeepCollectionEquality().equals;
+
+    return other is Snap &&
+        deepEquals(other.apps, apps) &&
+        other.base == base &&
+        deepEquals(other.categories, categories) &&
+        other.channel == channel &&
+        deepEquals(other.channels, channels) &&
+        deepEquals(other.commonIds, commonIds) &&
+        other.confinement == confinement &&
+        other.contact == contact &&
+        other.description == description &&
+        other.devmode == devmode &&
+        other.downloadSize == downloadSize &&
+        other.hold == hold &&
+        other.id == id &&
+        other.installDate == installDate &&
+        other.installedSize == installedSize &&
+        other.jailmode == jailmode &&
+        other.license == license &&
+        deepEquals(other.media, media) &&
+        other.mountedFrom == mountedFrom &&
+        other.name == name &&
+        other.private == private &&
+        other.publisher == publisher &&
+        other.revision == revision &&
+        other.status == status &&
+        other.storeUrl == storeUrl &&
+        other.summary == summary &&
+        other.title == title &&
+        other.trackingChannel == trackingChannel &&
+        deepEquals(other.tracks, tracks) &&
+        other.type == type &&
+        other.version == version &&
+        other.website == website;
+  }
+
+  @override
+  int get hashCode {
+    final deepHash = const DeepCollectionEquality().hash;
+    return Object.hashAll([
+      deepHash(apps),
+      base,
+      deepHash(categories),
+      channel,
+      deepHash(channels),
+      deepHash(commonIds),
+      confinement,
+      contact,
+      description,
+      devmode,
+      downloadSize,
+      hold,
+      id,
+      installDate,
+      installedSize,
+      jailmode,
+      license,
+      deepHash(media),
+      mountedFrom,
+      name,
+      private,
+      publisher,
+      revision,
+      status,
+      storeUrl,
+      summary,
+      title,
+      trackingChannel,
+      deepHash(tracks),
+      type,
+      version,
+      website
+    ]);
+  }
 }
 
 /// Response received when getting system information.

--- a/test/snapd_test.dart
+++ b/test/snapd_test.dart
@@ -1497,41 +1497,41 @@ void main() {
     var snaps = await client.getSnaps();
     expect(snaps, hasLength(1));
     var snap = snaps[0];
-    expect(
-        snap,
-        equals(Snap(
-            apps: [],
-            base: null,
-            categories: [],
-            channel: '',
-            channels: {},
-            commonIds: [],
-            confinement: SnapConfinement.unknown,
-            contact: '',
-            description: 'Hello\nSalut\nHola',
-            devmode: false,
-            downloadSize: null,
-            hold: null,
-            id: 'QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV',
-            installDate: null,
-            installedSize: null,
-            jailmode: false,
-            license: null,
-            media: [],
-            mountedFrom: null,
-            name: 'hello',
-            private: false,
-            publisher: null,
-            revision: '42',
-            status: SnapStatus.unknown,
-            storeUrl: null,
-            summary: 'Hello is an app',
-            title: 'Hello',
-            trackingChannel: null,
-            tracks: [],
-            type: 'app',
-            version: '1.2',
-            website: null)));
+    var expectedSnap = Snap(
+        apps: [],
+        base: null,
+        categories: [],
+        channel: '',
+        channels: {},
+        commonIds: [],
+        confinement: SnapConfinement.unknown,
+        contact: '',
+        description: 'Hello\nSalut\nHola',
+        devmode: false,
+        downloadSize: null,
+        hold: null,
+        id: 'QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV',
+        installDate: null,
+        installedSize: null,
+        jailmode: false,
+        license: null,
+        media: [],
+        mountedFrom: null,
+        name: 'hello',
+        private: false,
+        publisher: null,
+        revision: '42',
+        status: SnapStatus.unknown,
+        storeUrl: null,
+        summary: 'Hello is an app',
+        title: 'Hello',
+        trackingChannel: null,
+        tracks: [],
+        type: 'app',
+        version: '1.2',
+        website: null);
+    expect(snap, equals(expectedSnap));
+    expect(snap.hashCode, equals(expectedSnap.hashCode));
     expect(
         snap.toString(),
         equals(
@@ -1616,71 +1616,71 @@ void main() {
     var snaps = await client.getSnaps();
     expect(snaps, hasLength(1));
     var snap = snaps[0];
-    expect(
-        snap,
-        equals(Snap(
-            apps: [
-              SnapApp(snap: 'hello', name: 'hello1'),
-              SnapApp(snap: 'hello', name: 'hello2')
-            ],
-            base: 'core20',
-            categories: [
-              SnapCategory(name: 'category1', featured: false),
-              SnapCategory(name: 'category2', featured: true)
-            ],
-            channel: 'stable',
-            channels: {
-              'latest/stable': SnapChannel(
-                  confinement: SnapConfinement.strict,
-                  releasedAt: DateTime.utc(2022, 5, 2, 21, 24, 15, 330, 374),
-                  revision: '42',
-                  size: 123456,
-                  version: '1.2'),
-              'insider/stable': SnapChannel(
-                  confinement: SnapConfinement.classic,
-                  releasedAt: DateTime.utc(2022, 4, 26, 12, 54, 32, 578, 86),
-                  revision: '43',
-                  size: 888888,
-                  version: '1.3')
-            },
-            commonIds: ['com.example.Hello', 'com.example.Hallo'],
-            contact: 'hello@example.com',
-            confinement: SnapConfinement.classic,
-            description: 'Hello\nSalut\nHola',
-            devmode: true,
-            downloadSize: 123456,
-            hold: DateTime.utc(2315, 6, 19, 13, 0, 37, 186, 885),
-            id: 'QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV',
-            installDate: DateTime.utc(2022, 5, 13, 9, 51, 3, 920, 998),
-            installedSize: 654321,
-            jailmode: true,
-            license: 'GPL-3',
-            media: [
-              SnapMedia(type: 'icon', url: 'http://example.com/hello-icon.png'),
-              SnapMedia(
-                  type: 'screenshot',
-                  url: 'http://example.com/hello-screenshot.jpg',
-                  width: 1024,
-                  height: 768)
-            ],
-            mountedFrom: '/var/lib/snapd/snaps/hello_1.2.snap',
-            name: 'hello',
-            private: true,
-            publisher: SnapPublisher(
-                id: 'JvtzsxbsHivZLdvzrt0iqW529riGLfXJ',
-                username: 'publisher',
-                displayName: 'Publisher',
-                validation: 'verified'),
-            revision: '42',
-            status: SnapStatus.available,
-            storeUrl: 'https://snapcraft.io/hello',
-            summary: 'Hello is an app',
-            title: 'Hello',
-            trackingChannel: 'latest/stable',
-            tracks: ['latest', 'insider'],
-            type: 'app',
-            version: '1.2',
-            website: 'http://example.com/hello')));
+    var expectedSnap = Snap(
+        apps: [
+          SnapApp(snap: 'hello', name: 'hello1'),
+          SnapApp(snap: 'hello', name: 'hello2')
+        ],
+        base: 'core20',
+        categories: [
+          SnapCategory(name: 'category1', featured: false),
+          SnapCategory(name: 'category2', featured: true)
+        ],
+        channel: 'stable',
+        channels: {
+          'latest/stable': SnapChannel(
+              confinement: SnapConfinement.strict,
+              releasedAt: DateTime.utc(2022, 5, 2, 21, 24, 15, 330, 374),
+              revision: '42',
+              size: 123456,
+              version: '1.2'),
+          'insider/stable': SnapChannel(
+              confinement: SnapConfinement.classic,
+              releasedAt: DateTime.utc(2022, 4, 26, 12, 54, 32, 578, 86),
+              revision: '43',
+              size: 888888,
+              version: '1.3')
+        },
+        commonIds: ['com.example.Hello', 'com.example.Hallo'],
+        contact: 'hello@example.com',
+        confinement: SnapConfinement.classic,
+        description: 'Hello\nSalut\nHola',
+        devmode: true,
+        downloadSize: 123456,
+        hold: DateTime.utc(2315, 6, 19, 13, 0, 37, 186, 885),
+        id: 'QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV',
+        installDate: DateTime.utc(2022, 5, 13, 9, 51, 3, 920, 998),
+        installedSize: 654321,
+        jailmode: true,
+        license: 'GPL-3',
+        media: [
+          SnapMedia(type: 'icon', url: 'http://example.com/hello-icon.png'),
+          SnapMedia(
+              type: 'screenshot',
+              url: 'http://example.com/hello-screenshot.jpg',
+              width: 1024,
+              height: 768)
+        ],
+        mountedFrom: '/var/lib/snapd/snaps/hello_1.2.snap',
+        name: 'hello',
+        private: true,
+        publisher: SnapPublisher(
+            id: 'JvtzsxbsHivZLdvzrt0iqW529riGLfXJ',
+            username: 'publisher',
+            displayName: 'Publisher',
+            validation: 'verified'),
+        revision: '42',
+        status: SnapStatus.available,
+        storeUrl: 'https://snapcraft.io/hello',
+        summary: 'Hello is an app',
+        title: 'Hello',
+        trackingChannel: 'latest/stable',
+        tracks: ['latest', 'insider'],
+        type: 'app',
+        version: '1.2',
+        website: 'http://example.com/hello');
+    expect(snap, equals(expectedSnap));
+    expect(snap.hashCode, equals(expectedSnap.hashCode));
     expect(
         snap.toString(),
         equals(

--- a/test/snapd_test.dart
+++ b/test/snapd_test.dart
@@ -1497,27 +1497,41 @@ void main() {
     var snaps = await client.getSnaps();
     expect(snaps, hasLength(1));
     var snap = snaps[0];
-    expect(snap.apps, isEmpty);
-    expect(snap.channel, equals(''));
-    expect(snap.channels, isEmpty);
-    expect(snap.commonIds, isEmpty);
-    expect(snap.contact, equals(''));
-    expect(snap.description, equals('Hello\nSalut\nHola'));
-    expect(snap.downloadSize, isNull);
-    expect(snap.id, equals('QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV'));
-    expect(snap.installedSize, isNull);
-    expect(snap.license, isNull);
-    expect(snap.media, isEmpty);
-    expect(snap.name, equals('hello'));
-    expect(snap.publisher, isNull);
-    expect(snap.revision, equals('42'));
-    expect(snap.storeUrl, isNull);
-    expect(snap.summary, equals('Hello is an app'));
-    expect(snap.title, equals('Hello'));
-    expect(snap.tracks, isEmpty);
-    expect(snap.type, equals('app'));
-    expect(snap.version, equals('1.2'));
-    expect(snap.website, isNull);
+    expect(
+        snap,
+        equals(Snap(
+            apps: [],
+            base: null,
+            categories: [],
+            channel: '',
+            channels: {},
+            commonIds: [],
+            confinement: SnapConfinement.unknown,
+            contact: '',
+            description: 'Hello\nSalut\nHola',
+            devmode: false,
+            downloadSize: null,
+            hold: null,
+            id: 'QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV',
+            installDate: null,
+            installedSize: null,
+            jailmode: false,
+            license: null,
+            media: [],
+            mountedFrom: null,
+            name: 'hello',
+            private: false,
+            publisher: null,
+            revision: '42',
+            status: SnapStatus.unknown,
+            storeUrl: null,
+            summary: 'Hello is an app',
+            title: 'Hello',
+            trackingChannel: null,
+            tracks: [],
+            type: 'app',
+            version: '1.2',
+            website: null)));
     expect(
         snap.toString(),
         equals(
@@ -1602,59 +1616,71 @@ void main() {
     var snaps = await client.getSnaps();
     expect(snaps, hasLength(1));
     var snap = snaps[0];
-    expect(snap.apps, hasLength(2));
-    expect(snap.apps[0].name, equals('hello1'));
-    expect(snap.apps[0].snap, equals('hello'));
-    expect(snap.apps[1].name, equals('hello2'));
-    expect(snap.base, equals('core20'));
-    expect(snap.categories, hasLength(2));
-    expect(snap.categories[0].name, equals('category1'));
-    expect(snap.categories[0].featured, isFalse);
-    expect(snap.categories[1].name, equals('category2'));
-    expect(snap.categories[1].featured, isTrue);
-    expect(snap.channel, equals('stable'));
-    expect(snap.channels, hasLength(2));
-    expect(snap.commonIds, equals(['com.example.Hello', 'com.example.Hallo']));
-    expect(snap.contact, equals('hello@example.com'));
-    expect(snap.confinement, equals(SnapConfinement.classic));
-    expect(snap.description, equals('Hello\nSalut\nHola'));
-    expect(snap.devmode, isTrue);
-    expect(snap.downloadSize, equals(123456));
-    expect(snap.hold, equals(DateTime.utc(2315, 6, 19, 13, 0, 37, 186, 885)));
-    expect(snap.id, equals('QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV'));
-    expect(snap.installDate,
-        equals(DateTime.utc(2022, 5, 13, 9, 51, 3, 920, 998)));
-    expect(snap.installedSize, equals(654321));
-    expect(snap.jailmode, isTrue);
-    expect(snap.license, equals('GPL-3'));
-    expect(snap.media, hasLength(2));
-    expect(snap.media[0].type, equals('icon'));
-    expect(snap.media[0].url, equals('http://example.com/hello-icon.png'));
-    expect(snap.media[0].width, isNull);
-    expect(snap.media[0].height, isNull);
-    expect(snap.media[1].type, equals('screenshot'));
     expect(
-        snap.media[1].url, equals('http://example.com/hello-screenshot.jpg'));
-    expect(snap.media[1].width, equals(1024));
-    expect(snap.media[1].height, equals(768));
-    expect(snap.mountedFrom, equals('/var/lib/snapd/snaps/hello_1.2.snap'));
-    expect(snap.name, equals('hello'));
-    expect(snap.private, isTrue);
-    expect(snap.publisher, isNotNull);
-    expect(snap.publisher!.id, equals('JvtzsxbsHivZLdvzrt0iqW529riGLfXJ'));
-    expect(snap.publisher!.username, equals('publisher'));
-    expect(snap.publisher!.displayName, equals('Publisher'));
-    expect(snap.publisher!.validation, equals('verified'));
-    expect(snap.revision, equals('42'));
-    expect(snap.status, equals(SnapStatus.available));
-    expect(snap.storeUrl, equals('https://snapcraft.io/hello'));
-    expect(snap.summary, equals('Hello is an app'));
-    expect(snap.title, equals('Hello'));
-    expect(snap.trackingChannel, equals('latest/stable'));
-    expect(snap.tracks, equals(['latest', 'insider']));
-    expect(snap.type, equals('app'));
-    expect(snap.version, equals('1.2'));
-    expect(snap.website, equals('http://example.com/hello'));
+        snap,
+        equals(Snap(
+            apps: [
+              SnapApp(snap: 'hello', name: 'hello1'),
+              SnapApp(snap: 'hello', name: 'hello2')
+            ],
+            base: 'core20',
+            categories: [
+              SnapCategory(name: 'category1', featured: false),
+              SnapCategory(name: 'category2', featured: true)
+            ],
+            channel: 'stable',
+            channels: {
+              'latest/stable': SnapChannel(
+                  confinement: SnapConfinement.strict,
+                  releasedAt: DateTime.utc(2022, 5, 2, 21, 24, 15, 330, 374),
+                  revision: '42',
+                  size: 123456,
+                  version: '1.2'),
+              'insider/stable': SnapChannel(
+                  confinement: SnapConfinement.classic,
+                  releasedAt: DateTime.utc(2022, 4, 26, 12, 54, 32, 578, 86),
+                  revision: '43',
+                  size: 888888,
+                  version: '1.3')
+            },
+            commonIds: ['com.example.Hello', 'com.example.Hallo'],
+            contact: 'hello@example.com',
+            confinement: SnapConfinement.classic,
+            description: 'Hello\nSalut\nHola',
+            devmode: true,
+            downloadSize: 123456,
+            hold: DateTime.utc(2315, 6, 19, 13, 0, 37, 186, 885),
+            id: 'QRDEfjn4WJYnm0FzDKwqqRZZI77awQEV',
+            installDate: DateTime.utc(2022, 5, 13, 9, 51, 3, 920, 998),
+            installedSize: 654321,
+            jailmode: true,
+            license: 'GPL-3',
+            media: [
+              SnapMedia(type: 'icon', url: 'http://example.com/hello-icon.png'),
+              SnapMedia(
+                  type: 'screenshot',
+                  url: 'http://example.com/hello-screenshot.jpg',
+                  width: 1024,
+                  height: 768)
+            ],
+            mountedFrom: '/var/lib/snapd/snaps/hello_1.2.snap',
+            name: 'hello',
+            private: true,
+            publisher: SnapPublisher(
+                id: 'JvtzsxbsHivZLdvzrt0iqW529riGLfXJ',
+                username: 'publisher',
+                displayName: 'Publisher',
+                validation: 'verified'),
+            revision: '42',
+            status: SnapStatus.available,
+            storeUrl: 'https://snapcraft.io/hello',
+            summary: 'Hello is an app',
+            title: 'Hello',
+            trackingChannel: 'latest/stable',
+            tracks: ['latest', 'insider'],
+            type: 'app',
+            version: '1.2',
+            website: 'http://example.com/hello')));
     expect(
         snap.toString(),
         equals(


### PR DESCRIPTION
Another partial fix to #90. Without deep equality, every `Snap` instance is seen as different even if they would contain equal values. Providing deep equality helps to avoid unnecessary rebuilds when using the `Snap` data class and its friends together with `StateNotifier` or `ValueNotifier`, for example.