### PR TITLE
feat: add support for the assertions endpoint

### DIFF
--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -1629,23 +1629,26 @@ class SnapdClient {
   /// Does a synchronous request to snapd.
   Future<dynamic> _getSync(String path,
       [Map<String, String> queryParameters = const {}]) async {
-    var request =
-        await _client.getUrl(Uri.http('localhost', path, queryParameters));
-    _setHeaders(request);
-    await request.close();
-    var snapdResponse = await _parseResponse(await request.done);
+    final response = await _getSyncResponse(path, queryParameters);
+    var snapdResponse = await _parseResponse(response);
     return snapdResponse.result;
   }
 
-  /// Does a syncronous request to snapd without parsing the response.
+  /// Does a synchronous request to snapd without parsing the response.
   Future<String> _getSyncRaw(String path,
+      [Map<String, String> queryParameters = const {}]) async {
+    final response = await _getSyncResponse(path, queryParameters);
+    return response.transform(utf8.decoder).join();
+  }
+
+  /// Does a synchronous request and returns the response.
+  Future<HttpClientResponse> _getSyncResponse(String path,
       [Map<String, String> queryParameters = const {}]) async {
     var request =
         await _client.getUrl(Uri.http('localhost', path, queryParameters));
     _setHeaders(request);
     await request.close();
-    final done = await request.done;
-    return await done.transform(utf8.decoder).join();
+    return await request.done;
   }
 
   /// Does a synchronous request to snapd.

--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -1477,7 +1477,10 @@ class SnapdClient {
 
   /// List all assertions of the given [assertion] type.
   /// If no [assertion] type is provided, lists available assertion types.
-  Future<Map<String, dynamic>> assertions(
+  /// If [params] are provided, the assertions are filtered to items that have
+  /// matching fields defined by their assertion type. More information can be
+  /// found in the snapd documentation: https://snapcraft.io/docs/snapd-rest-api#heading--assertion-type
+  Future<Map<String, dynamic>> getAssertions(
       {String? assertion, Map<String, String>? params}) async {
     if (assertion == null) {
       final result = await _getSync('/v2/assertions');

--- a/lib/src/snapd_client.g.dart
+++ b/lib/src/snapd_client.g.dart
@@ -213,6 +213,31 @@ const _$SnapStatusEnumMap = {
   SnapStatus.active: 'active',
 };
 
+SnapDeclaration _$SnapDeclarationFromJson(Map json) => SnapDeclaration(
+      type: json['type'] as String? ?? '',
+      authorityId: json['authority-id'] as String? ?? '',
+      revision: json['revision'] as int? ?? 0,
+      series: json['series'] as int? ?? 0,
+      snapId: json['snap-id'] as String? ?? '',
+      publisherId: json['publisher-id'] as String? ?? '',
+      snapName: json['snap-name'] as String? ?? '',
+      timestamp: json['timestamp'] as String? ?? '',
+      signKey: json['sign-key'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$SnapDeclarationToJson(SnapDeclaration instance) =>
+    <String, dynamic>{
+      'type': instance.type,
+      'authority-id': instance.authorityId,
+      'revision': instance.revision,
+      'series': instance.series,
+      'snap-id': instance.snapId,
+      'publisher-id': instance.publisherId,
+      'snap-name': instance.snapName,
+      'timestamp': instance.timestamp,
+      'sign-key': instance.signKey,
+    };
+
 SnapdSystemInfoResponse _$SnapdSystemInfoResponseFromJson(Map json) =>
     SnapdSystemInfoResponse(
       architecture: json['architecture'] as String? ?? '',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   json_annotation: ^4.8.1
   meta: ^1.8.0
   path: ^1.8.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/test/snapd_test.dart
+++ b/test/snapd_test.dart
@@ -2425,7 +2425,7 @@ void main() {
     });
 
     var assertion =
-        await client.assertions(assertion: 'snap-declaration', params: {
+        await client.getAssertions(assertion: 'snap-declaration', params: {
       'series': '16',
       'remote': 'true',
       'snap-id': 'bearId',


### PR DESCRIPTION
Snaps currently can't be obtained by their ID, but they can be via the [`assertions` snapd endpoint](https://snapcraft.io/docs/snapd-rest-api#heading--remote-assertion). The endpoint isn't currently implemented in this client, so this adds support for it, ~~as well as a convenience function to find a snap by its ID~~.

Finding a snap by ID is going to be required by [App Center](https://github.com/ubuntu/app-center)'s gaming tab, since I'll need to be able to obtain a snap from its [rating](https://github.com/ubuntu/app-center-ratings) (which only contains the ID), similar to what's already described in https://github.com/canonical/snapd.dart/issues/99.

Fixes https://github.com/canonical/snapd.dart/issues/99.