### PR TITLE
feat: Add convenience function for finding snaps by ID

### DIFF
--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -1475,6 +1475,28 @@ class SnapdClient {
     return snaps;
   }
 
+  /// Convenience function to find a snap by its ID. Under the hood, this
+  /// function combines the [assertions] and [find] endpoints.
+  ///
+  /// If no snap is found, this function will return null.
+  Future<Snap?> findById(String snapId,
+      {String? series, String? remote}) async {
+    final queryParameters = {
+      'series': series ?? '16',
+      'remote': remote ?? 'true',
+      'snap-id': snapId,
+    };
+    final result = await getAssertions(
+        assertion: 'snap-declaration', params: queryParameters);
+    final declaration = SnapDeclaration.fromJson(result);
+    final findResult = await find(name: declaration.snapName);
+    final matchingSnaps = findResult
+        .where((element) => element.id == declaration.snapId)
+        .firstOrNull;
+
+    return matchingSnaps;
+  }
+
   /// List all assertions of the given [assertion] type.
   /// If no [assertion] type is provided, lists available assertion types.
   /// If [params] are provided, the assertions are filtered to items that have

--- a/test/snapd_test.dart
+++ b/test/snapd_test.dart
@@ -2391,6 +2391,59 @@ void main() {
     expect(snaps[0].name, equals('unstable'));
   });
 
+  test('findByID', () async {
+    var snapd = MockSnapdServer(storeSnaps: [
+      MockSnap(name: 'swordfish', id: 'swordfishId', channels: {
+        'latest/stable': MockChannel(
+            channel: 'latest/stable', version: '1.0', revision: '1'),
+      }),
+      MockSnap(name: 'bear', id: 'bearId', channels: {
+        'latest/stable':
+            MockChannel(channel: 'latest/stable', version: '1.0', revision: '1')
+      }),
+      MockSnap(name: 'fis', id: 'fish1Id', channels: {
+        'latest/stable':
+            MockChannel(channel: 'latest/stable', version: '1.0', revision: '1')
+      }),
+      MockSnap(name: 'fi', id: 'fish2Id', channels: {
+        'latest/stable':
+            MockChannel(channel: 'latest/stable', version: '1.0', revision: '1')
+      }),
+      MockSnap(name: 'fish', id: 'fish3Id', channels: {
+        'latest/stable':
+            MockChannel(channel: 'latest/stable', version: '1.0', revision: '1')
+      })
+    ], snapDeclarations: [
+      MockSnapDeclaration(
+          series: 16, snapName: 'swordfish', snapId: 'swordfishId'),
+      MockSnapDeclaration(series: 16, snapName: 'bear', snapId: 'bearId'),
+      MockSnapDeclaration(series: 16, snapName: 'fis', snapId: 'fish1Id'),
+      MockSnapDeclaration(series: 16, snapName: 'fi', snapId: 'fish2Id'),
+      MockSnapDeclaration(series: 16, snapName: 'fish', snapId: 'fish3Id')
+    ]);
+    await snapd.start();
+    addTearDown(() async {
+      await snapd.close();
+    });
+
+    var client = SnapdClient(socketPath: snapd.socketPath);
+    addTearDown(() async {
+      client.close();
+    });
+
+    var snap = await client.findById('slugId');
+    expect(snap, isNull);
+
+    snap = await client.findById('bearId');
+    expect(snap, isNotNull);
+    expect(snap?.name, equals('bear'));
+
+    // make sure the underlying 'find' looks for the proper snap ID
+    snap = await client.findById('fish2Id');
+    expect(snap, isNotNull);
+    expect(snap?.name, equals('fi'));
+  });
+
   test('assertions', () async {
     var snapd = MockSnapdServer(storeSnaps: [
       MockSnap(name: 'swordfish', id: 'swordfishId', channels: {


### PR DESCRIPTION
As discussed in https://github.com/canonical/snapd.dart/pull/104#issuecomment-2057903070, the convenience function was moved to this PR. It works by first asserting for the snap ID using my previous PR (https://github.com/canonical/snapd.dart/pull/104), then using the existing `find` to get the full snap data.