### PR TITLE
fix: Return empty maps for invalid YAML strings

### DIFF
--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -859,8 +859,12 @@ class SnapdClient {
     }
 
     final raw = await _getSyncRaw('/v2/assertions/$assertion', params ?? {});
-    final yaml = loadYaml(raw, recover: true) as YamlMap? ?? YamlMap.wrap({});
-    return Map<String, dynamic>.from(yaml);
+    try {
+      final yaml = loadYaml(raw, recover: true) as YamlMap? ?? YamlMap.wrap({});
+      return Map<String, dynamic>.from(yaml);
+    } on YamlException catch (_) {
+      return {};
+    }
   }
 
   /// Logs into the snap store.


### PR DESCRIPTION
Some assertions from the snapd API include `*` as a value for some keys (notably, the [Cups](https://github.com/OpenPrinting/cups-snap) snap, see below), which is technically invalid YAML and produces exceptions. This PR fixes this by wrapping the YAML parser in a `try`/`catch` and returning an empty `Map` on parsing errors.

For example, here is the response for the Cups snap:
```bash
$SNAP/usr/bin/curl -sS -X GET --unix-socket /run/snapd.socket "http://localhost/v2/assertions/snap-declaration?series=16&remote=true&snap-id=m1eQacDdXCthEwWQrESei3Zao3d5gfJF"
```
```yaml
type: snap-declaration
format: 4
authority-id: canonical
revision: 12
series: 16
snap-id: m1eQacDdXCthEwWQrESei3Zao3d5gfJF
plugs:
  avahi-control:
    allow-auto-connection: true
  cups:
    allow-auto-connection:
      # \/ This is not valid YAML \/
      slots-per-plug: *
  cups-control:
    allow-auto-connection:
      slot-snap-type:
        - core
    allow-connection:
      slot-snap-type:
        - core
  network-manager-observe:
    allow-auto-connection: true
  raw-usb:
    allow-auto-connection: true
  system-files:
    allow-auto-connection: true
    allow-installation:
      plug-attributes:
        read: /etc/cups
      plug-names:
        - etc-cups
publisher-id: LTqT2FzRuRSUbVW5H27OpuWIyFs3EUKl
slots:
  cups:
    allow-auto-connection: true
    allow-connection: true
    allow-installation:
      slot-snap-type:
        - app
  cups-control:
    allow-connection: true
    allow-installation:
      slot-snap-type:
        - app
    deny-auto-connection: true
snap-name: cups
timestamp: 2022-06-16T03:55:10.349174Z
sign-key-sha3-384: key_here
```