### PR TITLE
chore: release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Add Snap.links
+
 ## 0.7.0
 
 * Update methods for interacting with prompting rules to work with new Snapd APIs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: snapd
-version: 0.7.0
+version: 0.7.1
 repository: https://github.com/canonical/snapd.dart
 description:
   Provides a client to access snapd, which allows you to manage, search and install snaps on a Linux system.


### PR DESCRIPTION
Release `0.7.1` with added support for `Snap.links` (#125)