### PR TITLE
chore: release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2
+
+* Add support for /v2/system-volumes
+
 ## 0.7.1
 
 * Add Snap.links

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: snapd
-version: 0.7.1
+version: 0.7.2
 repository: https://github.com/canonical/snapd.dart
 description:
   Provides a client to access snapd, which allows you to manage, search and install snaps on a Linux system.


### PR DESCRIPTION
Releases `0.7.2` including the implementation of the new `/v2/system-volumes` API from #127

UDENG-7178
UDENG-7185
UDENG-7186
UDENG-7187