### PR TITLE
chore: release 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.4
+
+* Add support for reverting snaps
+* Add support for listing snap revisions
+* Add support for `replace-platform-key` action
+* Add support for `/v2/system-info/storage-encrypted`
+* Add support for `delete-keyslots` action
+
 ## 0.7.3
 
 * Add support for /v2/icons
@@ -28,7 +36,7 @@
 
 * Add refresh inhibit properties to snap class
 * Exposes methods to interact with the prompting endpoints
- 
+
 ## 0.6.1
 
 * Downgrade version constraints due to Flutter's version pinning.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: snapd
-version: 0.7.3
+version: 0.7.4
 repository: https://github.com/canonical/snapd.dart
 description:
   Provides a client to access snapd, which allows you to manage, search and install snaps on a Linux system.


### PR DESCRIPTION
Releases all the changes since 0.7.3, see the changelog.