### PR TITLE
fix: ensure posted data is utf-8 encoded

### DIFF
--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -1522,7 +1522,8 @@ class SnapdClient {
   Future<T> _postSync<T>(String path, [dynamic body]) async {
     final request = await _client.post('localhost', 0, path);
     _setHeaders(request);
-    request.headers.contentType = ContentType('application', 'json');
+    request.headers.contentType =
+        ContentType('application', 'json', charset: 'utf-8');
     request.write(json.encode(body));
     await request.close();
     final snapdResponse = await _parseResponse(await request.done);
@@ -1547,7 +1548,8 @@ class SnapdClient {
   Future<String> _openAsync(String method, String path, [dynamic body]) async {
     final request = await _client.open(method, 'localhost', 0, path);
     _setHeaders(request);
-    request.headers.contentType = ContentType('application', 'json');
+    request.headers.contentType =
+        ContentType('application', 'json', charset: 'utf-8');
     request.write(json.encode(body));
     await request.close();
     final snapdResponse = await _parseResponse(await request.done);

--- a/lib/src/snapd_client.dart
+++ b/lib/src/snapd_client.dart
@@ -743,14 +743,12 @@ class SnapdClient {
 
   /// Loads the saved authorization for this user.
   Future<void> loadAuthorization({String? path}) async {
-    if (path == null) {
-      final home = Platform.environment['HOME'];
-      if (home == null) {
-        throw 'Unable to determine home directory';
-      }
-      path = p.join(home, '.snap', 'auth.json');
-    }
-    final file = File(path);
+    final home = Platform.environment['HOME'];
+    final resolvedPath = path ??
+        (home != null
+            ? p.join(home, '.snap', 'auth.json')
+            : (throw StateError('Unable to determine home directory')));
+    final file = File(resolvedPath);
     String contents;
     try {
       contents = await file.readAsString();

--- a/test/snapd_test.dart
+++ b/test/snapd_test.dart
@@ -4215,6 +4215,12 @@ void main() {
         newPassphrase: 'new',
         expectError: true,
       ),
+      (
+        name: 'correct encoding',
+        oldPassphrase: 'correct',
+        newPassphrase: 'pässwörd',
+        expectError: false,
+      ),
     ]) {
       test(testCase.name, () async {
         final snapd = MockSnapdServer(


### PR DESCRIPTION
I noticed that passphrases containing non-ASCII characters set up via the security center (which uses this library here), aren't accepted by plymouth during subsequent boots.
Turns out the underlying reason is that the HTTP client from dart:io defaults to latin-1 unless an explicit charset is specified, seee https://api.dart.dev/dart-io/HttpClientRequest-class.html
> If no charset is provided the default of ISO-8859-1 (Latin 1) is used.

This PR adds UTF-8 charset headers to requests sent to snapd.

UDENG-10653