### PR TITLE
ci: remove repository CLA check

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,9 +1,0 @@
-name: cla-check
-on: [pull_request_target]
-
-jobs:
-  cla-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
## Summary

Remove the dedicated repository-level CLA workflow now that CLA checking is provided by the organization-wide GitHub Action.

## Validation

- Confirmed no remaining CLA action references under `.github/workflows`
- Confirmed no workflow dependencies reference the removed check
- Ran `git diff --check`